### PR TITLE
feat: 전역 예외 처리기 및 표준 오류 응답 구현

### DIFF
--- a/src/main/java/foodiepass/server/global/error/BaseException.java
+++ b/src/main/java/foodiepass/server/global/error/BaseException.java
@@ -1,0 +1,19 @@
+package foodiepass.server.global.error;
+
+import lombok.Getter;
+
+@Getter
+public abstract class BaseException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BaseException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BaseException(ErrorCode errorCode, Object... args) {
+        super(errorCode.getMessage(args));
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/foodiepass/server/global/error/ErrorCode.java
+++ b/src/main/java/foodiepass/server/global/error/ErrorCode.java
@@ -1,0 +1,12 @@
+package foodiepass.server.global.error;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus getStatus();
+    String getMessage();
+
+    default String getMessage(Object... args){
+        return String.format(this.getMessage(), args);
+    }
+}

--- a/src/main/java/foodiepass/server/global/error/ErrorResponse.java
+++ b/src/main/java/foodiepass/server/global/error/ErrorResponse.java
@@ -1,0 +1,4 @@
+package foodiepass.server.global.error;
+
+public record ErrorResponse(int status, String message) {
+}

--- a/src/main/java/foodiepass/server/global/error/GlobalErrorCode.java
+++ b/src/main/java/foodiepass/server/global/error/GlobalErrorCode.java
@@ -1,0 +1,32 @@
+package foodiepass.server.global.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GlobalErrorCode implements ErrorCode {
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력 값입니다."),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "리소스를 찾을 수 없습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 메소드입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
+    MISSING_HEADER(HttpStatus.BAD_REQUEST, "요청에 필요한 헤더가 존재하지 않습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근이 금지되었습니다.");
+
+    public static final String PREFIX = "[GLOBAL ERROR] ";
+
+    private final HttpStatus status;
+    private final String rawMessage;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return PREFIX + rawMessage;
+    }
+}

--- a/src/main/java/foodiepass/server/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/foodiepass/server/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,69 @@
+package foodiepass.server.global.error;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BaseException.class)
+    protected ResponseEntity<ErrorResponse> handleBaseException(BaseException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        log.warn(">> 비즈니스 예외 발생: {}", e.getMessage(), e);
+        return createResponseEntity(errorCode, e.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        ErrorCode errorCode = GlobalErrorCode.INVALID_INPUT_VALUE;
+
+        String detailMessage = e.getBindingResult().getFieldErrors().stream()
+                .map(fieldError -> String.format("'%s' 필드: %s", fieldError.getField(), fieldError.getDefaultMessage()))
+                .collect(Collectors.joining(", "));
+
+        log.warn(">> 입력값 유효성 검사 실패: {}", detailMessage);
+        return createResponseEntity(errorCode, detailMessage);
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        log.warn(">> 지원하지 않는 HTTP 메소드 요청: [{}], 요청 URI: [{}]", e.getMethod(), e.getMessage());
+        return createResponseEntity(GlobalErrorCode.METHOD_NOT_ALLOWED);
+    }
+
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    protected ResponseEntity<ErrorResponse> handleMissingRequestHeaderException(MissingRequestHeaderException e) {
+        ErrorCode errorCode = GlobalErrorCode.MISSING_HEADER;
+        String message = String.format("필수 헤더('%s')가 요청에 포함되지 않았습니다.", e.getHeaderName());
+        log.warn(">> 필수 요청 헤더 누락: {}", message);
+        return createResponseEntity(errorCode, message);
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error(">> 처리되지 않은 예외 발생: {}", e.getMessage(), e);
+        return createResponseEntity(GlobalErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    private ResponseEntity<ErrorResponse> createResponseEntity(ErrorCode errorCode) {
+        return new ResponseEntity<>(
+                new ErrorResponse(errorCode.getStatus().value(), errorCode.getMessage()),
+                errorCode.getStatus()
+        );
+    }
+
+    private ResponseEntity<ErrorResponse> createResponseEntity(ErrorCode errorCode, String message) {
+        return new ResponseEntity<>(
+                new ErrorResponse(errorCode.getStatus().value(), message),
+                errorCode.getStatus()
+        );
+    }
+}


### PR DESCRIPTION
# 📄 Work Description
애플리케이션 전역에서 발생하는 예외를 중앙에서 일관되게 처리하고, 클라이언트에게 표준화된 오류 응답을 제공하기 위한 기반을 마련했습니다. 이를 통해 컨트롤러의 try-catch 블록과 같은 반복적인 예외 처리 코드를 제거하고, 비즈니스 로직의 가독성과 유지보수성을 향상시켰습니다.

1. GlobalExceptionHandler 구현

   - `@RestControllerAdvice`를 이용하여 프로젝트 전역의 예외를 처리하는 핸들러를 구현했습니다.

   - MethodArgumentNotValidException 등 자주 발생하는 스프링 예외에 대한 개별 핸들러를 추가하여, 더 상세하고 유용한 오류 메시지를 제공하도록 했습니다.

2. 표준 오류 응답 체계 정의

   - BaseException: 모든 커스텀 비즈니스 예외가 상속받는 추상 클래스를 정의했습니다.

   - ErrorCode, GlobalErrorCode: 오류의 상태 코드와 메시지를 체계적으로 관리하기 위한 인터페이스와 Enum을 구현했습니다.

   - ErrorResponse: 클라이언트에게 반환될 최종 오류 응답의 포맷을 정의한 DTO입니다.

# 🤔 고민한 내용
1. 예외 처리 로직의 중앙화

   - 고민: 각 서비스나 컨트롤러에서 예외를 try-catch로 처리할 경우, 로직이 분산되고 중복 코드가 발생하며 일관된 응답을 보장하기 어렵다고 판단했습니다.

   - 결정: `@RestControllerAdvice`를 통해 AOP 방식으로 예외를 처리하여, 핵심 로직과 예외 처리라는 관심사를 명확히 분리(SoC)했습니다. 이를 통해 모든 예외 처리를 한 곳에서 관리하여 유지보수성을 높였습니다.

2. 상세한 오류 메시지 제공

   - 고민: 단순히 "잘못된 요청"이라는 메시지 대신, 어떤 필드가 왜 잘못되었는지 알려주는 것이 클라이언트 개발 경험에 매우 중요하다고 생각했습니다.

   - 결정: MethodArgumentNotValidException 핸들러 내부에서 BindingResult를 분석하여, " 'fieldName' 필드: {defaultMessage} "와 같이 실질적으로 도움이 되는 상세 오류 메시지를 동적으로 생성하여 반환하도록 구현했습니다.
