### PR TITLE
feat: ResponseBodyAdvice를 이용한 성공 응답 자동 래핑 구현

### DIFF
--- a/src/main/java/foodiepass/server/global/GlobalResponseAdvice.java
+++ b/src/main/java/foodiepass/server/global/GlobalResponseAdvice.java
@@ -1,0 +1,33 @@
+package foodiepass.server.global;
+
+import foodiepass.server.global.error.ErrorResponse;
+import foodiepass.server.global.success.GlobalSuccessCode;
+import foodiepass.server.global.success.SuccessResponse;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice(basePackages = "foodiepass.server")
+public class GlobalResponseAdvice implements ResponseBodyAdvice<Object> {
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        Class<?> parameterType = returnType.getParameterType();
+        return !(parameterType.equals(ErrorResponse.class) || parameterType.equals(SuccessResponse.class));
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType,
+                                  Class<? extends HttpMessageConverter<?>> selectedConverterType,
+                                  ServerHttpRequest request, ServerHttpResponse response) {
+        if (body == null) {
+            return null;
+        }
+
+        return SuccessResponse.of(GlobalSuccessCode.OK, body);
+    }
+}

--- a/src/main/java/foodiepass/server/global/GlobalResponseAdvice.java
+++ b/src/main/java/foodiepass/server/global/GlobalResponseAdvice.java
@@ -5,6 +5,7 @@ import foodiepass.server.global.success.GlobalSuccessCode;
 import foodiepass.server.global.success.SuccessResponse;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
@@ -17,7 +18,9 @@ public class GlobalResponseAdvice implements ResponseBodyAdvice<Object> {
     @Override
     public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
         Class<?> parameterType = returnType.getParameterType();
-        return !(parameterType.equals(ErrorResponse.class) || parameterType.equals(SuccessResponse.class));
+        return !(parameterType.equals(ErrorResponse.class) ||
+                parameterType.equals(SuccessResponse.class) ||
+                parameterType.equals(ResponseEntity.class));
     }
 
     @Override
@@ -25,7 +28,7 @@ public class GlobalResponseAdvice implements ResponseBodyAdvice<Object> {
                                   Class<? extends HttpMessageConverter<?>> selectedConverterType,
                                   ServerHttpRequest request, ServerHttpResponse response) {
         if (body == null) {
-            return null;
+            return SuccessResponse.from(GlobalSuccessCode.OK);
         }
 
         return SuccessResponse.of(GlobalSuccessCode.OK, body);

--- a/src/main/java/foodiepass/server/global/success/GlobalSuccessCode.java
+++ b/src/main/java/foodiepass/server/global/success/GlobalSuccessCode.java
@@ -1,0 +1,15 @@
+package foodiepass.server.global.success;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GlobalSuccessCode implements SuccessCode {
+    OK(HttpStatus.OK, "요청이 성공적으로 처리되었습니다."),
+    CREATED(HttpStatus.CREATED, "리뷰가 성공적으로 생성되었습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/foodiepass/server/global/success/SuccessCode.java
+++ b/src/main/java/foodiepass/server/global/success/SuccessCode.java
@@ -1,0 +1,12 @@
+package foodiepass.server.global.success;
+
+import org.springframework.http.HttpStatus;
+
+public interface SuccessCode {
+    HttpStatus getStatus();
+    String getMessage();
+
+    default String getMessage(Object... args) {
+        return String.format(this.getMessage(), args);
+    }
+}

--- a/src/main/java/foodiepass/server/global/success/SuccessResponse.java
+++ b/src/main/java/foodiepass/server/global/success/SuccessResponse.java
@@ -1,0 +1,18 @@
+package foodiepass.server.global.success;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+public record SuccessResponse<T>(
+        int status,
+        String message,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        T result
+) {
+    public static <T> SuccessResponse<T> of(SuccessCode successCode, T result) {
+        return new SuccessResponse<>(successCode.getStatus().value(), successCode.getMessage(), result);
+    }
+
+    public static <T> SuccessResponse<T> from(SuccessCode successCode) {
+        return new SuccessResponse<>(successCode.getStatus().value(), successCode.getMessage(), null);
+    }
+}


### PR DESCRIPTION
# 📄 Work Description
API의 성공 응답을 표준화하고, 컨트롤러의 반복적인 응답 포장 코드를 제거하여 개발 생산성을 향상시켰습니다. ResponseBodyAdvice를 도입하여 컨트롤러가 순수한 데이터(DTO)만 반환해도, 응답이 나가는 시점에 자동으로 표준 SuccessResponse 형식으로 감싸주도록 구현했습니다.

1. GlobalResponseAdvice 구현

    - ResponseBodyAdvice를 구현하여 컨트롤러의 반환 값을 가로채, 표준 성공 응답 DTO인 SuccessResponse로 포장하는 로직을 추가했습니다.
    -  supports() 메소드를 통해 이미 SuccessResponse나 ErrorResponse로 포장된 응답은 다시 포장하지 않도록 하여, 명시적인 응답 제어도 가능하게 만들었습니다.

2. 표준 성공 응답 체계 정의

    - SuccessResponse<T>: 제네릭을 사용하여 모든 성공 응답을 담는 표준 DTO를 정의했습니다.
    - SuccessCode, GlobalSuccessCode: 성공 상태 코드와 메시지를 관리하는 인터페이스와 Enum을 구현했습니다.

3. 컨트롤러 코드 간소화

    - 위 Advice 적용으로, 이제 대부분의 컨트롤러는 ResponseEntity나 SuccessResponse를 직접 생성할 필요 없이 순수 DTO만 반환하면 됩니다.

# 🤔 고민한 내용 

1. ResponseBodyAdvice 도입의 장단점

    - 고민: ResponseBodyAdvice는 내부 동작을 모르면 코드를 파악하기 어려울 수 있다는 단점이 있습니다. 모든 컨트롤러에서 명시적으로 SuccessResponse를 생성하는 것이 더 직관적이지 않을까 고민했습니다.
    - 결정: 반복적인 포장 코드를 제거함으로써 얻는 생산성 향상과 코드 간결성의 이점이 훨씬 크다고 판단했습니다. 이는 DRY(Don't Repeat Yourself) 원칙을 지키는 더 좋은 설계이며, Advice의 존재만 인지하면 오히려 개발자가 비즈니스 로직에만 집중할 수 있게 돕는다고 결론 내렸습니다.

2. 코드의 통일성 vs 원칙의 통일성

    - 고민: "어떤 메소드는 DTO를, 어떤 메소드는 ResponseEntity를 반환하는데 이게 통일성이 있는가?" 라는 의문이 있었습니다.
    - 결정: 코드 작성 방식의 표면적인 통일성보다, "일반적인 경우는 자동화하고, 특별한 경우만 수동으로 제어한다*는 '원칙의 통일성'을 추구했습니다. 그 결과, 서버 내부 구현은 유연해지면서도 클라이언트가 받는 최종 API 응답의 구조는 100% 일관되게 유지되는, 더 높은 수준의 통일성을 달성했습니다.