### PR TITLE
feat: 통화 및 언어 도메인 Enum 및 예외 처리 구현

### DIFF
--- a/src/main/java/foodiepass/server/currency/domain/Currency.java
+++ b/src/main/java/foodiepass/server/currency/domain/Currency.java
@@ -1,0 +1,201 @@
+package foodiepass.server.currency.domain;
+
+import static foodiepass.server.currency.exception.CurrencyErrorCode.CURRENCY_NOT_FOUND;
+
+import foodiepass.server.currency.exception.CurrencyException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public enum Currency {
+
+    AFGHAN_AFGHANI("Afghan Afghani", "AFN"),
+    ALBANIAN_LEK("Albanian Lek", "ALL"),
+    ALGERIAN_DINAR("Algerian Dinar", "DZD"),
+    ANGOLAN_KWANZA("Angolan Kwanza", "AOA"),
+    ARGENTINE_PESO("Argentine Peso", "ARS"),
+    ARMENIAN_DRAM("Armenian Dram", "AMD"),
+    ARUBAN_FLORIN("Aruban Florin", "AWG"),
+    AUSTRALIAN_DOLLAR("Australian Dollar", "AUD"),
+    AZERBAIJANI_MANAT("Azerbaijani Manat", "AZN"),
+    BAHAMIAN_DOLLAR("Bahamian Dollar", "BSD"),
+    BAHRAINI_DINAR("Bahraini Dinar", "BHD"),
+    BAJAN_DOLLAR("Bajan dollar", "BBD"),
+    BANGLADESHI_TAKA("Bangladeshi Taka", "BDT"),
+    BELARUSIAN_RUBLE("Belarusian Ruble", "BYN"),
+    BELIZE_DOLLAR("Belize Dollar", "BZD"),
+    BERMUDA_DOLLAR("Bermuda Dollar", "BMD"),
+    BHUTANESE_NGULTRUM("Bhutanese Ngultrum", "BTN"),
+    BOLIVIAN_BOLIVIANO("Bolivian boliviano", "BOB"),
+    BOSNIA_HERZEGOVINA_CONVERTIBLE_MARKA("Bosnia-Herzegovina Convertible Marka", "BAM"),
+    BOTSWANAN_PULA("Botswanan Pula", "BWP"),
+    BRAZILIAN_REAL("Brazilian Real", "BRL"),
+    BRUNEI_DOLLAR("Brunei Dollar", "BND"),
+    BULGARIAN_LEV("Bulgarian Lev", "BGN"),
+    BURUNDIAN_FRANC("Burundian Franc", "BIF"),
+    CFP_FRANC("CFP Franc", "XPF"),
+    CAMBODIAN_RIEL("Cambodian riel", "KHR"),
+    CANADIAN_DOLLAR("Canadian Dollar", "CAD"),
+    CAPE_VERDEAN_ESCUDO("Cape Verdean Escudo", "CVE"),
+    CAYMAN_ISLANDS_DOLLAR("Cayman Islands Dollar", "KYD"),
+    CENTRAL_AFRICAN_CFA_FRANC("Central African CFA franc", "XAF"),
+    CHILEAN_PESO("Chilean Peso", "CLP"),
+    CHILEAN_UNIT_OF_ACCOUNT_UF("Chilean Unit of Account (UF)", "CLF"),
+    CHINESE_YUAN("Chinese Yuan", "CNY"),
+    CHINESE_YUAN_OFFSHORE("Chinese Yuan (offshore)", "CNH"),
+    COLOMBIAN_PESO("Colombian Peso", "COP"),
+    COMORIAN_FRANC("Comorian Franc", "KMF"),
+    CONGOLESE_FRANC("Congolese Franc", "CDF"),
+    COSTA_RICAN_COLON("Costa Rican Colón", "CRC"),
+    CUBAN_PESO("Cuban Peso", "CUP"),
+    CZECH_KORUNA("Czech Koruna", "CZK"),
+    DANISH_KRONE("Danish Krone", "DKK"),
+    DJIBOUTIAN_FRANC("Djiboutian Franc", "DJF"),
+    DOMINICAN_PESO("Dominican Peso", "DOP"),
+    EAST_CARIBBEAN_DOLLAR("East Caribbean Dollar", "XCD"),
+    EGYPTIAN_POUND("Egyptian Pound", "EGP"),
+    ETHIOPIAN_BIRR("Ethiopian Birr", "ETB"),
+    EURO("Euro", "EUR"),
+    FIJIAN_DOLLAR("Fijian Dollar", "FJD"),
+    GAMBIAN_DALASI("Gambian Dalasi", "GMD"),
+    GEORGIAN_LARI("Georgian Lari", "GEL"),
+    GHANAIAN_CEDI("Ghanaian Cedi", "GHS"),
+    GUATEMALAN_QUETZAL("Guatemalan Quetzal", "GTQ"),
+    GUINEAN_FRANC("Guinean Franc", "GNF"),
+    GUYANESE_DOLLAR("Guyanese dollar", "GYD"),
+    HAITIAN_GOURDE("Haitian Gourde", "HTG"),
+    HONDURAN_LEMPIRA("Honduran Lempira", "HNL"),
+    HONG_KONG_DOLLAR("Hong Kong Dollar", "HKD"),
+    HUNGARIAN_FORINT("Hungarian Forint", "HUF"),
+    ICELANDIC_KRONA("Icelandic Króna", "ISK"),
+    INDIAN_RUPEE("Indian Rupee", "INR"),
+    INDONESIAN_RUPIAH("Indonesian Rupiah", "IDR"),
+    IRANIAN_RIAL("Iranian Rial", "IRR"),
+    IRAQI_DINAR("Iraqi Dinar", "IQD"),
+    ISRAELI_NEW_SHEKEL("Israeli New Shekel", "ILS"),
+    JAMAICAN_DOLLAR("Jamaican Dollar", "JMD"),
+    JAPANESE_YEN("Japanese Yen", "JPY"),
+    JORDANIAN_DINAR("Jordanian Dinar", "JOD"),
+    KAZAKHSTANI_TENGE("Kazakhstani Tenge", "KZT"),
+    KENYAN_SHILLING("Kenyan Shilling", "KES"),
+    KUWAITI_DINAR("Kuwaiti Dinar", "KWD"),
+    KYRGYZSTANI_SOM("Kyrgystani Som", "KGS"),
+    LAOTIAN_KIP("Laotian Kip", "LAK"),
+    LEBANESE_POUND("Lebanese pound", "LBP"),
+    LESOTHO_LOTI("Lesotho Loti", "LSL"),
+    LIBERIAN_DOLLAR("Liberian Dollar", "LRD"),
+    LIBYAN_DINAR("Libyan Dinar", "LYD"),
+    MACANESE_PATACA("Macanese Pataca", "MOP"),
+    MACEDONIAN_DENAR("Macedonian Denar", "MKD"),
+    MALAGASY_ARIARY("Malagasy Ariary", "MGA"),
+    MALAWIAN_KWACHA("Malawian Kwacha", "MWK"),
+    MALAYSIAN_RINGGIT("Malaysian Ringgit", "MYR"),
+    MALDIVIAN_RUFIYAA("Maldivian Rufiyaa", "MVR"),
+    MAURITANIAN_OUGUIYA_1973_2017("Mauritanian Ouguiya (1973–2017)", "MRU"),
+    MAURITIAN_RUPEE("Mauritian Rupee", "MUR"),
+    MEXICAN_PESO("Mexican Peso", "MXN"),
+    MOLDOVAN_LEU("Moldovan Leu", "MDL"),
+    MOROCCAN_DIRHAM("Moroccan Dirham", "MAD"),
+    MOZAMBICAN_METICAL("Mozambican metical", "MZN"),
+    MYANMAR_KYAT("Myanmar Kyat", "MMK"),
+    NAMIBIAN_DOLLAR("Namibian Dollar", "NAD"),
+    NEPALESE_RUPEE("Nepalese Rupee", "NPR"),
+    NETHERLANDS_ANTILLEAN_GUILDER("Netherlands Antillean Guilder", "ANG"),
+    NEW_TAIWAN_DOLLAR("New Taiwan dollar", "TWD"),
+    NEW_ZEALAND_DOLLAR("New Zealand Dollar", "NZD"),
+    NICARAGUAN_CORDOBA("Nicaraguan Córdoba", "NIO"),
+    NIGERIAN_NAIRA("Nigerian Naira", "NGN"),
+    NORWEGIAN_KRONE("Norwegian Krone", "NOK"),
+    OMANI_RIAL("Omani Rial", "OMR"),
+    PAKISTANI_RUPEE("Pakistani Rupee", "PKR"),
+    PANAMANIAN_BALBOA("Panamanian Balboa", "PAB"),
+    PAPUA_NEW_GUINEAN_KINA("Papua New Guinean Kina", "PGK"),
+    PARAGUAYAN_GUARANI("Paraguayan Guarani", "PYG"),
+    PHILIPPINE_PESO("Philippine peso", "PHP"),
+    POLISH_ZLOTY("Polish złoty", "PLN"),
+    POUND_STERLING("Pound sterling", "GBP"),
+    QATARI_RIYAL("Qatari Riyal", "QAR"),
+    ROMANIAN_LEU("Romanian Leu", "RON"),
+    RUSSIAN_RUBLE("Russian Ruble", "RUB"),
+    RWANDAN_FRANC("Rwandan Franc", "RWF"),
+    SALVADORAN_COLON("Salvadoran Colón", "SVC"),
+    SAUDI_RIYAL("Saudi Riyal", "SAR"),
+    SERBIAN_DINAR("Serbian Dinar", "RSD"),
+    SEYCHELLOIS_RUPEE("Seychellois Rupee", "SCR"),
+    SIERRA_LEONEAN_LEONE_1964_2022("Sierra Leonean Leone (1964—2022)", "SLL"),
+    SINGAPORE_DOLLAR("Singapore Dollar", "SGD"),
+    SOL("Sol", "PEN"),
+    SOLOMON_ISLANDS_DOLLAR("Solomon Islands Dollar", "SBD"),
+    SOMALI_SHILLING("Somali Shilling", "SOS"),
+    SOUTH_AFRICAN_RAND("South African Rand", "ZAR"),
+    SOUTH_KOREAN_WON("South Korean won", "KRW"),
+    SOVEREIGN_BOLIVAR("Sovereign Bolivar", "VES"),
+    SRI_LANKAN_RUPEE("Sri Lankan Rupee", "LKR"),
+    SUDANESE_POUND("Sudanese pound", "SDG"),
+    SURINAME_DOLLAR("Suriname Dollar", "SRD"),
+    SWAZI_LILANGENI("Swazi Lilangeni", "SZL"),
+    SWEDISH_KRONA("Swedish Krona", "SEK"),
+    SWISS_FRANC("Swiss Franc", "CHF"),
+    TAJIKISTANI_SOMONI("Tajikistani Somoni", "TJS"),
+    TANZANIAN_SHILLING("Tanzanian Shilling", "TZS"),
+    THAI_BAHT("Thai Baht", "THB"),
+    TONGAN_PA_ANGA("Tongan Paʻanga", "TOP"),
+    TRINIDAD_TOBAGO_DOLLAR("Trinidad & Tobago Dollar", "TTD"),
+    TUNISIAN_DINAR("Tunisian Dinar", "TND"),
+    TURKISH_LIRA("Turkish lira", "TRY"),
+    TURKMENISTANI_MANAT("Turkmenistani Manat", "TMT"),
+    UGANDAN_SHILLING("Ugandan Shilling", "UGX"),
+    UKRAINIAN_HRYVNIA("Ukrainian hryvnia", "UAH"),
+    UNITED_ARAB_EMIRATES_DIRHAM("United Arab Emirates Dirham", "AED"),
+    UNITED_STATES_DOLLAR("United States Dollar", "USD"),
+    URUGUAYAN_PESO("Uruguayan peso", "UYU"),
+    UZBEKISTANI_SOM("Uzbekistani Som", "UZS"),
+    VIETNAMESE_DONG("Vietnamese dong", "VND"),
+    WEST_AFRICAN_CFA_FRANC("West African CFA franc", "XOF"),
+    YEMENI_RIAL("Yemeni Rial", "YER"),
+    ZAMBIAN_KWACHA("Zambian Kwacha", "ZMW");
+
+    private final String currencyName;
+    private final String currencyCode;
+
+    private static final Map<String, Currency> CODE_TO_CURRENCY_MAP;
+    private static final Map<String, Currency> NAME_TO_CURRENCY_MAP;
+
+    static {
+        CODE_TO_CURRENCY_MAP = Collections.unmodifiableMap(
+                Stream.of(values())
+                        .collect(Collectors.toMap(Currency::getCurrencyCode, Function.identity()))
+        );
+
+        NAME_TO_CURRENCY_MAP = Collections.unmodifiableMap(
+                Stream.of(values())
+                        .collect(Collectors.toMap(Currency::getCurrencyName, Function.identity()))
+        );
+    }
+
+    Currency(final String currencyName, final String currencyCode) {
+        this.currencyName = currencyName;
+        this.currencyCode = currencyCode;
+    }
+
+    public static Currency fromCurrencyName(final String currencyName) {
+        return Optional.ofNullable(NAME_TO_CURRENCY_MAP.get(currencyName))
+                .orElseThrow(() -> new CurrencyException(CURRENCY_NOT_FOUND));
+    }
+
+    public static Currency fromCurrencyCode(final String code) {
+        return Optional.ofNullable(CODE_TO_CURRENCY_MAP.get(code))
+                .orElseThrow(() -> new CurrencyException(CURRENCY_NOT_FOUND));
+    }
+
+    public String getCurrencyName() {
+        return currencyName;
+    }
+
+    public String getCurrencyCode() {
+        return currencyCode;
+    }
+}

--- a/src/main/java/foodiepass/server/currency/exception/CurrencyErrorCode.java
+++ b/src/main/java/foodiepass/server/currency/exception/CurrencyErrorCode.java
@@ -1,0 +1,27 @@
+package foodiepass.server.currency.exception;
+
+import foodiepass.server.global.error.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum CurrencyErrorCode implements ErrorCode {
+
+    CURRENCY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 통화를 찾을 수 없습니다."),
+    ;
+    private static final String PREFIX = "[CURRENCY ERROR] ";
+    private final HttpStatus status;
+    private final String rawMessage;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return PREFIX + rawMessage;
+    }
+}

--- a/src/main/java/foodiepass/server/currency/exception/CurrencyException.java
+++ b/src/main/java/foodiepass/server/currency/exception/CurrencyException.java
@@ -1,0 +1,9 @@
+package foodiepass.server.currency.exception;
+
+import foodiepass.server.global.error.BaseException;
+
+public class CurrencyException extends BaseException {
+    public CurrencyException(CurrencyErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/foodiepass/server/language/domain/Language.java
+++ b/src/main/java/foodiepass/server/language/domain/Language.java
@@ -1,0 +1,197 @@
+package foodiepass.server.language.domain;
+
+import static foodiepass.server.language.exception.LanguageErrorCode.LANGUAGE_NOT_FOUND;
+
+import foodiepass.server.language.exception.LanguageException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public enum Language {
+
+    AFRIKAANS("Afrikaans", "af"),
+    ALBANIAN("Albanian", "sq"),
+    AMHARIC("Amharic", "am"),
+    ARABIC("Arabic", "ar"),
+    ARMENIAN("Armenian", "hy"),
+    ASSAMESE("Assamese", "as"),
+    AYMARA("Aymara", "ay"),
+    AZERBAIJANI("Azerbaijani", "az"),
+    BAMBARA("Bambara", "bm"),
+    BASQUE("Basque", "eu"),
+    BELARUSIAN("Belarusian", "be"),
+    BENGALI("Bengali", "bn"),
+    BHOJPURI("Bhojpuri", "bho"),
+    BOSNIAN("Bosnian", "bs"),
+    BULGARIAN("Bulgarian", "bg"),
+    CATALAN("Catalan", "ca"),
+    CEBUANO("Cebuano", "ceb"),
+    CHINESE_SIMPLIFIED("Chinese (Simplified)", "zh-CN or zh (BCP-47)"),
+    CHINESE_TRADITIONAL("Chinese (Traditional)", "zh-TW (BCP-47)"),
+    CORSICAN("Corsican", "co"),
+    CROATIAN("Croatian", "hr"),
+    CZECH("Czech", "cs"),
+    DANISH("Danish", "da"),
+    DHIVEHI("Dhivehi", "dv"),
+    DOGRI("Dogri", "doi"),
+    DUTCH("Dutch", "nl"),
+    ENGLISH("English", "en"),
+    ESPERANTO("Esperanto", "eo"),
+    ESTONIAN("Estonian", "et"),
+    EWE("Ewe", "ee"),
+    FILIPINO_TAGLAOG("Filipino (Tagalog)", "fil"),
+    FINNISH("Finnish", "fi"),
+    FRENCH("French", "fr"),
+    FRISIAN("Frisian", "fy"),
+    GALICIAN("Galician", "gl"),
+    GEORGIAN("Georgian", "ka"),
+    GERMAN("German", "de"),
+    GREEK("Greek", "el"),
+    GUARANI("Guarani", "gn"),
+    GUJARATI("Gujarati", "gu"),
+    HAITIAN_CREOLE("Haitian Creole", "ht"),
+    HAUSA("Hausa", "ha"),
+    HAWAIIAN("Hawaiian", "haw"),
+    HEBREW("Hebrew", "he or iw"),
+    HINDI("Hindi", "hi"),
+    HMONG("Hmong", "hmn"),
+    HUNGARIAN("Hungarian", "hu"),
+    ICELANDIC("Icelandic", "is"),
+    IGBO("Igbo", "ig"),
+    ILOCANO("Ilocano", "ilo"),
+    INDONESIAN("Indonesian", "id"),
+    IRISH("Irish", "ga"),
+    ITALIAN("Italian", "it"),
+    JAPANESE("Japanese", "ja"),
+    JAVANESE("Javanese", "jv or jw"),
+    KANNADA("Kannada", "kn"),
+    KAZAKH("Kazakh", "kk"),
+    KHMER("Khmer", "km"),
+    KINYARWANDA("Kinyarwanda", "rw"),
+    KONKANI("Konkani", "gom"),
+    KOREAN("Korean", "ko"),
+    KRIO("Krio", "kri"),
+    KURDISH("Kurdish", "ku"),
+    KURDISH_SORANI("Kurdish (Sorani)", "ckb"),
+    KYRGYZ("Kyrgyz", "ky"),
+    LAO("Lao", "lo"),
+    LATIN("Latin", "la"),
+    LATVIAN("Latvian", "lv"),
+    LINGALA("Lingala", "ln"),
+    LITHUANIAN("Lithuanian", "lt"),
+    LUGANDA("Luganda", "lg"),
+    LUXEMBOURGISH("Luxembourgish", "lb"),
+    MACEDONIAN("Macedonian", "mk"),
+    MAITHILI("Maithili", "mai"),
+    MALAGASY("Malagasy", "mg"),
+    MALAY("Malay", "ms"),
+    MALAYALAM("Malayalam", "ml"),
+    MALTESE("Maltese", "mt"),
+    MAORI("Maori", "mi"),
+    MARATHI("Marathi", "mr"),
+    MEITEILON_MANIPURI("Meiteilon (Manipuri)", "mni-Mtei"),
+    MIZO("Mizo", "lus"),
+    MONGOLIAN("Mongolian", "mn"),
+    MYANMAR_BURMESE("Myanmar (Burmese)", "my"),
+    NEPALI("Nepali", "ne"),
+    NORWEGIAN("Norwegian", "no"),
+    NYANJA_CHICHEWA("Nyanja (Chichewa)", "ny"),
+    ODIA_ORIYA("Odia (Oriya)", "or"),
+    OROMO("Oromo", "om"),
+    PASHTO("Pashto", "ps"),
+    PERSIAN("Persian", "fa"),
+    POLISH("Polish", "pl"),
+    PORTUGUESE_PORTUGAL_BRAZIL("Portuguese (Portugal, Brazil)", "pt"),
+    PUNJABI("Punjabi", "pa"),
+    QUECHUA("Quechua", "qu"),
+    ROMANIAN("Romanian", "ro"),
+    RUSSIAN("Russian", "ru"),
+    SAMOAN("Samoan", "sm"),
+    SANSKRIT("Sanskrit", "sa"),
+    SCOTS_GAELIC("Scots Gaelic", "gd"),
+    SEPEDI("Sepedi", "nso"),
+    SERBIAN("Serbian", "sr"),
+    SESOTHO("Sesotho", "st"),
+    SHONA("Shona", "sn"),
+    SINDHI("Sindhi", "sd"),
+    SINHALA_SINHALESE("Sinhala (Sinhalese)", "si"),
+    SLOVAK("Slovak", "sk"),
+    SLOVENIAN("Slovenian", "sl"),
+    SOMALI("Somali", "so"),
+    SPANISH("Spanish", "es"),
+    SUNDANESE("Sundanese", "su"),
+    SWAHILI("Swahili", "sw"),
+    SWEDISH("Swedish", "sv"),
+    TAGALOG_FILIPINO("Tagalog (Filipino)", "tl"),
+    TAJIK("Tajik", "tg"),
+    TAMIL("Tamil", "ta"),
+    TATAR("Tatar", "tt"),
+    TELUGU("Telugu", "te"),
+    THAI("Thai", "th"),
+    TIGRINYA("Tigrinya", "ti"),
+    TSONGA("Tsonga", "ts"),
+    TURKISH("Turkish", "tr"),
+    TURKMEN("Turkmen", "tk"),
+    TWI_AKAN("Twi (Akan)", "ak"),
+    UKRAINIAN("Ukrainian", "uk"),
+    URDU("Urdu", "ur"),
+    UYGHUR("Uyghur", "ug"),
+    UZBEK("Uzbek", "uz"),
+    VIETNAMESE("Vietnamese", "vi"),
+    WELSH("Welsh", "cy"),
+    XHOSA("Xhosa", "xh"),
+    YIDDISH("Yiddish", "yi"),
+    YORUBA("Yoruba", "yo"),
+    ZULU("Zulu", "zu");
+
+    private final String languageName;
+    private final String languageCode;
+
+    private static final Map<String, Language> NAME_TO_LANGUAGE_MAP;
+    private static final Map<String, Language> CODE_TO_LANGUAGE_MAP;
+
+    static {
+        NAME_TO_LANGUAGE_MAP = Collections.unmodifiableMap(
+                Stream.of(values())
+                        .collect(Collectors.toMap(Language::getLanguageName, Function.identity()))
+        );
+
+        Map<String, Language> codeMap = new HashMap<>();
+        for (Language language : values()) {
+            String[] codes = language.getLanguageCode()
+                    .replaceAll("\\s*\\(.*?\\)\\s*", "")
+                    .split("\\s+or\\s+");
+            for (String code : codes) {
+                codeMap.put(code, language);
+            }
+        }
+        CODE_TO_LANGUAGE_MAP = Collections.unmodifiableMap(codeMap);
+    }
+
+    Language(final String languageName, final String languageCode) {
+        this.languageName = languageName;
+        this.languageCode = languageCode;
+    }
+
+    public static Language fromLanguageName(final String languageName) {
+        return Optional.ofNullable(NAME_TO_LANGUAGE_MAP.get(languageName))
+                .orElseThrow(() -> new LanguageException(LANGUAGE_NOT_FOUND));
+    }
+
+    public static Language fromLanguageCode(final String code) {
+        return Optional.ofNullable(CODE_TO_LANGUAGE_MAP.get(code))
+                .orElseThrow(() -> new LanguageException(LANGUAGE_NOT_FOUND));
+    }
+
+    public String getLanguageName() {
+        return languageName;
+    }
+
+    public String getLanguageCode() {
+        return languageCode;
+    }
+}

--- a/src/main/java/foodiepass/server/language/exception/LanguageErrorCode.java
+++ b/src/main/java/foodiepass/server/language/exception/LanguageErrorCode.java
@@ -1,0 +1,28 @@
+package foodiepass.server.language.exception;
+
+import foodiepass.server.global.error.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum LanguageErrorCode implements ErrorCode {
+
+    LANGUAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "지원하지 않는 언어입니다."),
+    ;
+
+    private static final String PREFIX = "[LANGUAGE ERROR] ";
+    private final HttpStatus status;
+    private final String rawMessage;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return PREFIX + rawMessage;
+    }
+}

--- a/src/main/java/foodiepass/server/language/exception/LanguageException.java
+++ b/src/main/java/foodiepass/server/language/exception/LanguageException.java
@@ -1,0 +1,9 @@
+package foodiepass.server.language.exception;
+
+import foodiepass.server.global.error.BaseException;
+
+public class LanguageException extends BaseException {
+    public LanguageException(LanguageErrorCode errorCode) {
+        super(errorCode);
+    }
+}


### PR DESCRIPTION
# 📄 Work Description

서버에서 사용할 통화(Currency)와 언어(Language) 데이터를 체계적으로 관리하기 위한 **도메인 Enum과 관련 예외 처리 시스템**을 구현했습니다. 

1.  **표준 데이터 관리를 위한 도메인 Enum 구현**
    * 전 세계 통화(ISO 4217)와 언어(ISO 639) 목록을 `Currency`와 `Language` Enum으로 각각 정의했습니다.

2.  **O(1) 조회를 통한 성능 최적화**
    * Enum 상수를 조회할 때마다 목록 전체를 순회하는 `stream().filter()` 방식 대신, **`static` 블록에서 미리 `Map`을 생성**해두는 방식을 적용했습니다.

3.  **예외 처리 도입**
    * `CurrencyException`, `CurrencyErrorCode`와 `LanguageException`, `LanguageErrorCode`를 구현하여 각 도메인에 특화된 예외 처리 기반을 마련했습니다.
  
# 🤔 고민한 내용

#### 1. Enum의 크기와 초기 로딩 성능

* **고민**: `Currency`와 `Language` Enum은 모두 100개가 넘는 많은 상수를 가지고 있습니다. 클래스가 처음 로딩될 때 `static` 블록에서 이 모든 상수를 순회하며 `Map`을 생성하는 것이 애플리케이션 시작 시간에 미미하게나마 영향을 주지 않을까 하는 우려가 있었습니다.
* **결정**: 이 초기화 과정은 **애플리케이션 생명주기 동안 단 한 번만 실행**됩니다. 반면, 조회 로직은 서비스가 운영되는 동안 수없이 호출될 수 있습니다. **일회성의 작은 초기 비용**을 감수하고 런타임 내내 **압도적인 조회 성능(O(1))**을 확보하는 것이 전체적인 시스템 효율성 측면에서 훨씬 더 큰 이점이라고 판단했습니다. 이는 "빠른 실패(Fail-fast)"와 "지연 최적화 회피(Avoid Premature Optimization)" 원칙에도 부합해서 선택했습니다.

#### 2. 조회 로직의 복잡성 vs. 데이터의 정확성

* **고민**: `Language` Enum의 경우, `"he or iw"`처럼 하나의 언어가 여러 개의 ISO 코드를 가질 수 있습니다. 이를 처리하기 위해 `static` 초기화 블록에서 문자열을 파싱하는 로직이 추가되어 단순 `Collectors.toMap()` 방식보다 코드가 다소 복잡해졌습니다. 단순히 첫 번째 코드만 사용하거나, 데이터를 더 단순한 형태로 정제하는 방안도 고려했습니다.
* **결정**: 코드의 단순함을 약간 포기하더라도, **실제 데이터의 명세를 정확하게 반영**하는 것이 더 중요하다고 판단했습니다. 여러 코드를 모두 지원함으로써 API를 사용하는 클라이언트나 다른 개발자가 어떤 코드를 사용하더라도 동일한 언어 객체를 일관되게 얻을 수 있다고 생각했습니다.

#### 3. 네이밍: 기술적 명확성 vs. 개발자의 직관성

* **고민**: 초기 필드명인 `iso4217Code`(통화), `iso639Code`(언어)는 기술 표준을 명시하여 매우 정확하다는 장점이 있다고 생각했습니다. 하지만 `Currency` 클래스 내에서는 `currencyCode`로, `Language` 클래스 내에서는 `languageCode`로 명명하는 것이 더 간결하고 직관적이지 않을까 하는 고민이 있었습니다.
* **결정**: **문맥(Context)의 힘**을 믿기로 했습니다. `Currency`라는 클래스 안에서 `currencyCode`는 그 의미가 명확하며, `Language` 클래스 안의 `languageCode` 또한 마찬가지입니다. 기술적 정확성을 약간 양보하더라도, 동료 개발자의 **코드 가독성과 개발 경험을 향상**시키는 것이 장기적으로 더 큰 이점이라고 판단하여 `currencyCode`, `languageCode`와 같이 더 직관적인 이름으로 최종 결정했습니다.