### PR TITLE
feat : 주문관련 VO 구현

### DIFF
--- a/src/main/java/foodiepass/server/order/domain/FoodInfo.java
+++ b/src/main/java/foodiepass/server/order/domain/FoodInfo.java
@@ -1,0 +1,12 @@
+package foodiepass.server.order.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class FoodInfo {
+    private final String description;
+    private final String image;
+    private final String previewImage;
+}

--- a/src/main/java/foodiepass/server/order/domain/MenuItem.java
+++ b/src/main/java/foodiepass/server/order/domain/MenuItem.java
@@ -1,0 +1,13 @@
+package foodiepass.server.order.domain;
+
+import foodiepass.server.price.domain.Price;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class MenuItem {
+    private final String name;
+    private final Price price;
+    private final FoodInfo foodInfo;
+}

--- a/src/main/java/foodiepass/server/order/domain/Order.java
+++ b/src/main/java/foodiepass/server/order/domain/Order.java
@@ -17,6 +17,6 @@ public class Order {
     public Price calculateTotalPrice() {
         return items.stream()
                 .map(OrderItem::calculateTotalPrice)
-                .reduce(new Price(this.currency, 0.0), Price::add);
+                .reduce(Price.zero(this.currency), Price::add);
     }
 }

--- a/src/main/java/foodiepass/server/order/domain/Order.java
+++ b/src/main/java/foodiepass/server/order/domain/Order.java
@@ -1,0 +1,22 @@
+package foodiepass.server.order.domain;
+
+import java.util.List;
+
+import foodiepass.server.currency.domain.Currency;
+import foodiepass.server.price.domain.Price;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class Order {
+
+    private final List<OrderItem> items;
+    private final Currency currency;
+
+    public Price calculateTotalPrice() {
+        return items.stream()
+                .map(OrderItem::calculateTotalPrice)
+                .reduce(new Price(this.currency, 0.0), Price::add);
+    }
+}

--- a/src/main/java/foodiepass/server/order/domain/OrderItem.java
+++ b/src/main/java/foodiepass/server/order/domain/OrderItem.java
@@ -1,0 +1,18 @@
+package foodiepass.server.order.domain;
+
+import foodiepass.server.price.domain.Price;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class OrderItem {
+
+    private final MenuItem menuItem;
+    private final int quantity;
+
+
+    public Price calculateTotalPrice() {
+        return menuItem.getPrice().multiply(quantity);
+    }
+}

--- a/src/main/java/foodiepass/server/order/domain/OrderItem.java
+++ b/src/main/java/foodiepass/server/order/domain/OrderItem.java
@@ -11,7 +11,6 @@ public class OrderItem {
     private final MenuItem menuItem;
     private final int quantity;
 
-
     public Price calculateTotalPrice() {
         return menuItem.getPrice().multiply(quantity);
     }

--- a/src/main/java/foodiepass/server/order/domain/Script.java
+++ b/src/main/java/foodiepass/server/order/domain/Script.java
@@ -1,0 +1,14 @@
+package foodiepass.server.order.domain;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@EqualsAndHashCode
+@RequiredArgsConstructor
+public final class Script {
+
+    private final String travelerScript;
+    private final String localScript;
+}

--- a/src/main/java/foodiepass/server/price/domain/Price.java
+++ b/src/main/java/foodiepass/server/price/domain/Price.java
@@ -15,6 +15,10 @@ public class Price {
     private final Currency currency;
     private final double amount;
 
+    public static Price zero(final Currency currency) {
+        return new Price(currency, 0.0);
+    }
+
     public Price add(final Price other) {
         if (!this.currency.equals(other.currency)) {
             throw new PriceException(PriceErrorCode.CURRENCIES_DO_NOT_MATCH);

--- a/src/test/java/foodiepass/server/order/domain/OrderItemTest.java
+++ b/src/test/java/foodiepass/server/order/domain/OrderItemTest.java
@@ -1,0 +1,65 @@
+package foodiepass.server.order.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import foodiepass.server.currency.domain.Currency;
+import foodiepass.server.price.domain.Price;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class OrderItemTest {
+
+    private MenuItem GUKBAP;
+
+    @BeforeEach
+    void setUp() {
+        FoodInfo gukbapInfo = new FoodInfo("따끈한 국밥", "gukbap.jpg", "gukbap_preview.jpg");
+        Price gukbapPrice = new Price(Currency.SOUTH_KOREAN_WON, 9000);
+        GUKBAP = new MenuItem("든든한 국밥", gukbapPrice, gukbapInfo);
+    }
+
+    @Test
+    @DisplayName("주문 항목의 총액을 정확히 계산한다")
+    void calculateTotalPrice_shouldReturnCorrectPriceForQuantity() {
+        // given
+        int quantity = 3;
+        OrderItem orderItem = new OrderItem(GUKBAP, quantity);
+        Price expectedPrice = new Price(Currency.SOUTH_KOREAN_WON, 27000);
+
+        // when
+        Price actualPrice = orderItem.calculateTotalPrice();
+
+        // then
+        assertThat(actualPrice).isEqualTo(expectedPrice);
+    }
+
+    @Test
+    @DisplayName("주문 수량이 1일 때, 메뉴의 단가와 동일한 총액을 반환한다")
+    void calculateTotalPrice_shouldReturnSamePriceForSingleQuantity() {
+        // given
+        int quantity = 1;
+        OrderItem orderItem = new OrderItem(GUKBAP, quantity);
+
+        // when
+        Price actualPrice = orderItem.calculateTotalPrice();
+
+        // then
+        assertThat(actualPrice).isEqualTo(GUKBAP.getPrice());
+    }
+
+    @Test
+    @DisplayName("주문 수량이 0일 때, 0원의 총액을 반환한다")
+    void calculateTotalPrice_shouldReturnZeroPriceForZeroQuantity() {
+        // given
+        int quantity = 0;
+        OrderItem orderItem = new OrderItem(GUKBAP, quantity);
+        Price expectedPrice = new Price(Currency.SOUTH_KOREAN_WON, 0);
+
+        // when
+        Price actualPrice = orderItem.calculateTotalPrice();
+
+        // then
+        assertThat(actualPrice).isEqualTo(expectedPrice);
+    }
+}

--- a/src/test/java/foodiepass/server/order/domain/OrderTest.java
+++ b/src/test/java/foodiepass/server/order/domain/OrderTest.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class OrderTest {
@@ -26,56 +27,59 @@ class OrderTest {
         KIMCHI_JJIGAE = new MenuItem("돼지고기 김치찌개", kimchiPrice, kimchiInfo);
     }
 
-    @Test
-    @DisplayName("여러 주문 항목들의 총액을 정확히 계산한다")
-    void calculateTotalPrice_shouldSumUpAllOrderItems() {
-        // given
-        OrderItem gukbapOrder = new OrderItem(GUKBAP, 2);
-        OrderItem kimchiOrder = new OrderItem(KIMCHI_JJIGAE, 1);
-        List<OrderItem> items = List.of(gukbapOrder, kimchiOrder);
+    @Nested
+    @DisplayName("calculateTotalPrice 메서드는")
+    class Describe_calculateTotalPrice {
 
-        Order order = new Order(items, Currency.SOUTH_KOREAN_WON);
+        @Test
+        @DisplayName("여러 주문 항목들의 총액을 정확히 계산한다")
+        void shouldSumUpAllOrderItems() {
+            // given
+            OrderItem gukbapOrder = new OrderItem(GUKBAP, 2);
+            OrderItem kimchiOrder = new OrderItem(KIMCHI_JJIGAE, 1);
+            List<OrderItem> items = List.of(gukbapOrder, kimchiOrder);
 
-        Price expectedPrice = new Price(Currency.SOUTH_KOREAN_WON, 26000);
+            Order order = new Order(items, Currency.SOUTH_KOREAN_WON);
 
-        // when
-        Price actualPrice = order.calculateTotalPrice();
+            Price expectedPrice = new Price(Currency.SOUTH_KOREAN_WON, 26000);
 
-        // then
-        assertThat(actualPrice).isEqualTo(expectedPrice);
-    }
+            // when
+            Price actualPrice = order.calculateTotalPrice();
 
-    @Test
-    @DisplayName("주문 항목이 하나일 때, 해당 항목의 총액을 반환한다")
-    void calculateTotalPrice_shouldWorkForSingleItem() {
-        // given
-        OrderItem gukbapOrder = new OrderItem(GUKBAP, 3);
-        List<OrderItem> items = List.of(gukbapOrder);
+            // then
+            assertThat(actualPrice).isEqualTo(expectedPrice);
+        }
 
-        Order order = new Order(items, Currency.SOUTH_KOREAN_WON);
+        @Test
+        @DisplayName("주문 항목이 하나일 때, 해당 항목의 총액을 반환한다")
+        void shouldWorkForSingleItem() {
+            // given
+            OrderItem gukbapOrder = new OrderItem(GUKBAP, 3);
+            List<OrderItem> items = List.of(gukbapOrder);
 
-        Price expectedPrice = new Price(Currency.SOUTH_KOREAN_WON, 27000);
+            Order order = new Order(items, Currency.SOUTH_KOREAN_WON);
 
-        // when
-        Price actualPrice = order.calculateTotalPrice();
+            Price expectedPrice = new Price(Currency.SOUTH_KOREAN_WON, 27000);
 
-        // then
-        assertThat(actualPrice).isEqualTo(expectedPrice);
-    }
+            // when
+            Price actualPrice = order.calculateTotalPrice();
 
-    @Test
-    @DisplayName("주문 항목이 없을 때, 0원의 총액을 반환한다")
-    void calculateTotalPrice_shouldReturnZeroForEmptyOrder() {
-        // given
-        List<OrderItem> emptyItems = Collections.emptyList();
-        Order order = new Order(emptyItems, Currency.SOUTH_KOREAN_WON);
+            // then
+            assertThat(actualPrice).isEqualTo(expectedPrice);
+        }
 
-        Price expectedPrice = new Price(Currency.SOUTH_KOREAN_WON, 0);
+        @Test
+        @DisplayName("주문 항목이 없을 때, 0원의 총액을 반환한다")
+        void shouldReturnZeroForEmptyOrder() {
+            // given
+            List<OrderItem> emptyItems = Collections.emptyList();
+            Order order = new Order(emptyItems, Currency.SOUTH_KOREAN_WON);
 
-        // when
-        Price actualPrice = order.calculateTotalPrice();
+            // when
+            Price actualPrice = order.calculateTotalPrice();
 
-        // then
-        assertThat(actualPrice).isEqualTo(expectedPrice);
+            // then
+            assertThat(actualPrice).isEqualTo(Price.zero(Currency.SOUTH_KOREAN_WON));
+        }
     }
 }

--- a/src/test/java/foodiepass/server/order/domain/OrderTest.java
+++ b/src/test/java/foodiepass/server/order/domain/OrderTest.java
@@ -1,0 +1,81 @@
+package foodiepass.server.order.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import foodiepass.server.currency.domain.Currency;
+import foodiepass.server.price.domain.Price;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class OrderTest {
+
+    private MenuItem GUKBAP;
+    private MenuItem KIMCHI_JJIGAE;
+
+    @BeforeEach
+    void setUp() {
+        FoodInfo gukbapInfo = new FoodInfo("따끈한 국밥", "gukbap.jpg", "gukbap_preview.jpg");
+        Price gukbapPrice = new Price(Currency.SOUTH_KOREAN_WON, 9000);
+        GUKBAP = new MenuItem("든든한 국밥", gukbapPrice, gukbapInfo);
+
+        FoodInfo kimchiInfo = new FoodInfo("매콤한 김치찌개", "kimchi.jpg", "kimchi_preview.jpg");
+        Price kimchiPrice = new Price(Currency.SOUTH_KOREAN_WON, 8000);
+        KIMCHI_JJIGAE = new MenuItem("돼지고기 김치찌개", kimchiPrice, kimchiInfo);
+    }
+
+    @Test
+    @DisplayName("여러 주문 항목들의 총액을 정확히 계산한다")
+    void calculateTotalPrice_shouldSumUpAllOrderItems() {
+        // given
+        OrderItem gukbapOrder = new OrderItem(GUKBAP, 2);
+        OrderItem kimchiOrder = new OrderItem(KIMCHI_JJIGAE, 1);
+        List<OrderItem> items = List.of(gukbapOrder, kimchiOrder);
+
+        Order order = new Order(items, Currency.SOUTH_KOREAN_WON);
+
+        Price expectedPrice = new Price(Currency.SOUTH_KOREAN_WON, 26000);
+
+        // when
+        Price actualPrice = order.calculateTotalPrice();
+
+        // then
+        assertThat(actualPrice).isEqualTo(expectedPrice);
+    }
+
+    @Test
+    @DisplayName("주문 항목이 하나일 때, 해당 항목의 총액을 반환한다")
+    void calculateTotalPrice_shouldWorkForSingleItem() {
+        // given
+        OrderItem gukbapOrder = new OrderItem(GUKBAP, 3);
+        List<OrderItem> items = List.of(gukbapOrder);
+
+        Order order = new Order(items, Currency.SOUTH_KOREAN_WON);
+
+        Price expectedPrice = new Price(Currency.SOUTH_KOREAN_WON, 27000);
+
+        // when
+        Price actualPrice = order.calculateTotalPrice();
+
+        // then
+        assertThat(actualPrice).isEqualTo(expectedPrice);
+    }
+
+    @Test
+    @DisplayName("주문 항목이 없을 때, 0원의 총액을 반환한다")
+    void calculateTotalPrice_shouldReturnZeroForEmptyOrder() {
+        // given
+        List<OrderItem> emptyItems = Collections.emptyList();
+        Order order = new Order(emptyItems, Currency.SOUTH_KOREAN_WON);
+
+        Price expectedPrice = new Price(Currency.SOUTH_KOREAN_WON, 0);
+
+        // when
+        Price actualPrice = order.calculateTotalPrice();
+
+        // then
+        assertThat(actualPrice).isEqualTo(expectedPrice);
+    }
+}

--- a/src/test/java/foodiepass/server/price/domain/PriceTest.java
+++ b/src/test/java/foodiepass/server/price/domain/PriceTest.java
@@ -14,6 +14,25 @@ import org.junit.jupiter.api.Test;
 class PriceTest {
 
     @Nested
+    @DisplayName("zero 정적 팩토리 메서드는")
+    class Describe_zero {
+
+        @Test
+        @DisplayName("주어진 통화에 대해 0 값을 가진 Price 객체를 생성한다")
+        void shouldReturnZeroAmountPriceWithGivenCurrency() {
+            // given
+            final Currency currency = Currency.SOUTH_KOREAN_WON;
+            final Price expectedPrice = new Price(currency, 0.0);
+
+            // when
+            final Price actualPrice = Price.zero(currency);
+
+            // then
+            assertThat(actualPrice).isEqualTo(expectedPrice);
+        }
+    }
+
+    @Nested
     @DisplayName("add 메서드는")
     class Describe_add {
 
@@ -23,13 +42,13 @@ class PriceTest {
             // given
             final Price price1 = new Price(Currency.SOUTH_KOREAN_WON, 1000.0);
             final Price price2 = new Price(Currency.SOUTH_KOREAN_WON, 500.0);
+            final Price expectedPrice = new Price(Currency.SOUTH_KOREAN_WON, 1500.0);
 
             // when
             final Price result = price1.add(price2);
 
             // then
-            assertThat(result.getAmount()).isEqualTo(1500.0);
-            assertThat(result.getCurrency()).isEqualTo(Currency.SOUTH_KOREAN_WON);
+            assertThat(result).isEqualTo(expectedPrice);
         }
 
         @Test
@@ -55,13 +74,13 @@ class PriceTest {
         void whenMultiplyingByPositiveQuantity_shouldReturnMultipliedPrice() {
             // given
             final Price price = new Price(Currency.SOUTH_KOREAN_WON, 1000.0);
+            final Price expectedPrice = new Price(Currency.SOUTH_KOREAN_WON, 3000.0);
 
             // when
             final Price result = price.multiply(3);
 
             // then
-            assertThat(result.getAmount()).isEqualTo(3000.0);
-            assertThat(result.getCurrency()).isEqualTo(Currency.SOUTH_KOREAN_WON);
+            assertThat(result).isEqualTo(expectedPrice);
         }
 
         @Test


### PR DESCRIPTION
# 📄 Work Description

* **도메인 모델 구조화**
    `Order`, `OrderItem`, `MenuItem`, `FoodInfo`, `Script` 등 주문의 핵심 개념을 담당하는 도메인 객체들을 정의했습니다.

* **객체지향 설계 원칙 적용**
    각 객체가 자신의 데이터를 책임지고 스스로 행위를 하도록 설계하여 응집도를 높였습니다. 예를 들어, 총액 계산 로직을 `Order`와 `OrderItem` 내부로 캡슐화하고, 가격(`Price`)과 스크립트(`Script`)는 불변 값 객체(Value Object)로 구현하여 시스템의 안정성을 향상시켰습니다.

* **핵심 로직 구현**
    `Order`의 `calculateTotalPrice` 메서드는 Stream API의 `map`과 `reduce`를 사용하여, '각 주문 항목의 가격을 계산하여 모두 더한다'는 비즈니스적 의도를 간결하고 선언적으로 표현했습니다.

* **단위 테스트 작성**
    핵심 도메인 로직(특히 총액 계산)이 다양한 시나리오(일반, 단일 항목, 빈 주문 등)에서 정확하게 동작하는지 검증하기 위해, `JUnit 5`와 `AssertJ`를 사용한 단위 테스트 코드를 작성했습니다.

# 🤔 고민한 내용

* **`OrderItem`의 설계: 값 복사 vs 객체 참조**
    * **고민**: `OrderItem`이 `menuName`이나 `price` 같은 원시 값을 직접 갖는 것이 `MenuItem` 객체 전체를 참조하는 것보다 더 단순하지 않을까 고민했습니다.
    * **결정**: `MenuItem` 객체를 직접 참조하는 방식을 선택했습니다. 이는 **데이터의 중복을 제거**하고 **단일 진실 공급원(Single Source of Truth)** 원칙을 지키는 더 나은 설계라고 판단했습니다. '주문 항목'은 '메뉴'의 정보를 복사한 것이 아니라 '메뉴' 그 자체를 가리키는 것이라는 도메인 개념을 코드에 더 정확히 반영한다고 생각했습니다.

* **`Order.calculateTotalPrice` 구현: `for`문 vs Stream API**
    * **고민**: `for`문은 모든 개발자에게 익숙하고 절차적으로 이해하기 쉽지만, Stream API는 선언적이고 함수형 스타일이라는 장점이 있었습니다. 어떤 방식이 코드의 의도를 더 잘 드러낼지 고민했습니다.
    * **결정**: Stream API를 사용했습니다. `for`문이 '어떻게' 계산하는지에 집중한다면, 스트림은 '무엇을' 계산하는지에 집중합니다. '각 항목의 가격을 구한 뒤, 그 합계를 낸다'는 비즈니스 로직의 흐름을 `map`과 `reduce`로 명확히 표현할 수 있어 가독성과 유지보수성 면에서 더 유리하다고 결론 내렸습니다.

* **`Price` 값 객체의 도입**
    * **고민**: 가격을 단순히 `double` 타입으로 처리할지, `Price`라는 별도의 값 객체를 만들지 고민했습니다.
    * **결정**: `Price` 값 객체를 도입했습니다. 가격은 '금액'과 '통화'가 결합되어야 의미를 갖는 중요한 비즈니스 개념입니다. 이를 객체로 캡슐화함으로써 타입 안정성을 높이고, 가격과 관련된 행위(계산 로직 등)를 한 곳에서 관리하여 원시 타입에 대한 집착(Primitive Obsession)을 피하는 선택했습니다.