### PR TITLE
feat: 메뉴 번역 및 지원 언어 조회 기능 구현

### DIFF
--- a/src/main/java/foodiepass/server/currency/exception/CurrencyException.java
+++ b/src/main/java/foodiepass/server/currency/exception/CurrencyException.java
@@ -1,10 +1,9 @@
 package foodiepass.server.currency.exception;
 
 import foodiepass.server.global.error.BaseException;
-import foodiepass.server.global.error.ErrorCode;
 
 public class CurrencyException extends BaseException {
-    public CurrencyException(ErrorCode errorCode) {
+    public CurrencyException(CurrencyErrorCode errorCode) {
         super(errorCode);
     }
 }

--- a/src/main/java/foodiepass/server/food/domain/TranslationClient.java
+++ b/src/main/java/foodiepass/server/food/domain/TranslationClient.java
@@ -1,0 +1,7 @@
+package foodiepass.server.food.domain;
+
+import foodiepass.server.language.domain.Language;
+
+public interface TranslationClient {
+  String translate(final Language from, final Language to, final String content);
+}

--- a/src/main/java/foodiepass/server/food/domain/TranslationClient.java
+++ b/src/main/java/foodiepass/server/food/domain/TranslationClient.java
@@ -1,7 +1,8 @@
 package foodiepass.server.food.domain;
 
 import foodiepass.server.language.domain.Language;
+import lombok.NonNull;
 
 public interface TranslationClient {
-  String translate(final Language from, final Language to, final String content);
+  String translate(@NonNull final Language from, @NonNull final Language to, @NonNull final String content);
 }

--- a/src/main/java/foodiepass/server/global/config/TranslationConfig.java
+++ b/src/main/java/foodiepass/server/global/config/TranslationConfig.java
@@ -1,0 +1,43 @@
+package foodiepass.server.global.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.translate.Translate;
+import com.google.cloud.translate.TranslateOptions;
+import foodiepass.server.food.domain.TranslationClient;
+import foodiepass.server.language.infra.GoogleTranslationClient;
+import java.io.IOException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+
+@Configuration
+public class TranslationConfig {
+
+    @Bean
+    public GoogleCredentials googleCredentials(
+            @Value("${google.credential.path}") final Resource credentialResource
+    ) throws IOException {
+        return GoogleCredentials.fromStream(credentialResource.getInputStream());
+    }
+
+    @Bean
+    public Translate translate(
+            final GoogleCredentials credentials,
+            @Value("${google.project-id}") final String projectId
+    ) {
+        return TranslateOptions.newBuilder()
+                .setCredentials(credentials)
+                .setProjectId(projectId)
+                .build()
+                .getService();
+    }
+
+    @Bean
+    public TranslationClient translationClient(
+            final Translate translate,
+            @Value("${google.translation.model}") final String translationModel
+    ) {
+        return new GoogleTranslationClient(translate, translationModel);
+    }
+}

--- a/src/main/java/foodiepass/server/language/api/LanguageController.java
+++ b/src/main/java/foodiepass/server/language/api/LanguageController.java
@@ -1,0 +1,21 @@
+package foodiepass.server.language.api;
+
+import foodiepass.server.language.application.LanguageService;
+import foodiepass.server.language.dto.response.LanguageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class LanguageController {
+
+    private final LanguageService languageService;
+
+    @GetMapping("/language")
+    public List<LanguageResponse> getLanguages() {
+        return languageService.findAllLanguages();
+    }
+}

--- a/src/main/java/foodiepass/server/language/application/LanguageService.java
+++ b/src/main/java/foodiepass/server/language/application/LanguageService.java
@@ -1,0 +1,22 @@
+package foodiepass.server.language.application;
+
+import foodiepass.server.language.domain.Language;
+import foodiepass.server.language.dto.response.LanguageResponse;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class LanguageService {
+
+    private static final List<LanguageResponse> CACHED_LANGUAGES =
+            Arrays.stream(Language.values())
+                    .map(LanguageResponse::from)
+                    .collect(Collectors.toUnmodifiableList());
+
+    public List<LanguageResponse> findAllLanguages() {
+        return CACHED_LANGUAGES;
+    }
+}

--- a/src/main/java/foodiepass/server/language/dto/response/LanguageResponse.java
+++ b/src/main/java/foodiepass/server/language/dto/response/LanguageResponse.java
@@ -1,0 +1,9 @@
+package foodiepass.server.language.dto.response;
+
+import foodiepass.server.language.domain.Language;
+
+public record LanguageResponse(String languageName) {
+    public static LanguageResponse from(final Language language) {
+        return new LanguageResponse(language.getLanguageName());
+    }
+}

--- a/src/main/java/foodiepass/server/language/exception/LanguageErrorCode.java
+++ b/src/main/java/foodiepass/server/language/exception/LanguageErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum LanguageErrorCode implements ErrorCode {
 
     LANGUAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "지원하지 않는 언어입니다."),
-    INVALID_LANGUAGE_INPUT(HttpStatus.BAD_REQUEST, "언어 이름 또는 코드는 비어있을 수 없습니다.");
+    INVALID_LANGUAGE_INPUT(HttpStatus.BAD_REQUEST, "언어 입력값이 유효하지 않습니다."),
+    TRANSLATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "텍스트 번역 중 오류가 발생했습니다.");
     ;
 
     private final HttpStatus status;

--- a/src/main/java/foodiepass/server/language/infra/GoogleTranslationClient.java
+++ b/src/main/java/foodiepass/server/language/infra/GoogleTranslationClient.java
@@ -7,12 +7,17 @@ import foodiepass.server.food.domain.TranslationClient;
 import foodiepass.server.language.domain.Language;
 import foodiepass.server.language.exception.LanguageErrorCode;
 import foodiepass.server.language.exception.LanguageException;
+import lombok.NonNull;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import static com.google.cloud.translate.Translate.TranslateOption.model;
 import static com.google.cloud.translate.Translate.TranslateOption.sourceLanguage;
 import static com.google.cloud.translate.Translate.TranslateOption.targetLanguage;
 
+@Component
 public class GoogleTranslationClient implements TranslationClient {
 
     private final Translate translate;
@@ -20,16 +25,20 @@ public class GoogleTranslationClient implements TranslationClient {
 
     public GoogleTranslationClient(
             final Translate translate,
-            final String translationModel
+            @Value("${google.translation.model}") final String translationModel
     ) {
         this.translate = translate;
         this.translationModel = translationModel;
     }
 
     @Override
-    @Cacheable(cacheNames = "translations")
-    public String translate(final Language from, final Language to, final String content) {
-        if (from.equals(to)) {
+    @Cacheable(cacheNames = "translations", key = "{#from.name(), #to.name(), #content}")
+    public String translate(
+            @NonNull final Language from,
+            @NonNull final Language to,
+            @NonNull final String content
+    ) {
+        if (!StringUtils.hasText(content) || from.equals(to)) {
             return content;
         }
 

--- a/src/main/java/foodiepass/server/language/infra/GoogleTranslationClient.java
+++ b/src/main/java/foodiepass/server/language/infra/GoogleTranslationClient.java
@@ -1,0 +1,48 @@
+package foodiepass.server.language.infra;
+
+import com.google.cloud.translate.Translate;
+import com.google.cloud.translate.TranslateException;
+import com.google.cloud.translate.Translation;
+import foodiepass.server.food.domain.TranslationClient;
+import foodiepass.server.language.domain.Language;
+import foodiepass.server.language.exception.LanguageErrorCode;
+import foodiepass.server.language.exception.LanguageException;
+import org.springframework.cache.annotation.Cacheable;
+
+import static com.google.cloud.translate.Translate.TranslateOption.model;
+import static com.google.cloud.translate.Translate.TranslateOption.sourceLanguage;
+import static com.google.cloud.translate.Translate.TranslateOption.targetLanguage;
+
+public class GoogleTranslationClient implements TranslationClient {
+
+    private final Translate translate;
+    private final String translationModel;
+
+    public GoogleTranslationClient(
+            final Translate translate,
+            final String translationModel
+    ) {
+        this.translate = translate;
+        this.translationModel = translationModel;
+    }
+
+    @Override
+    @Cacheable(cacheNames = "translations")
+    public String translate(final Language from, final Language to, final String content) {
+        if (from.equals(to)) {
+            return content;
+        }
+
+        try {
+            final Translation translation = translate.translate(
+                    content,
+                    sourceLanguage(from.getLanguageCode()),
+                    targetLanguage(to.getLanguageCode()),
+                    model(translationModel)
+            );
+            return translation.getTranslatedText();
+        } catch (final TranslateException e) {
+            throw new LanguageException(LanguageErrorCode.TRANSLATION_FAILED);
+        }
+    }
+}

--- a/src/test/java/foodiepass/server/language/application/LanguageServiceTest.java
+++ b/src/test/java/foodiepass/server/language/application/LanguageServiceTest.java
@@ -1,0 +1,75 @@
+package foodiepass.server.language.application;
+
+import foodiepass.server.language.domain.Language;
+import foodiepass.server.language.dto.response.LanguageResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class LanguageServiceTest {
+
+    private LanguageService languageService;
+
+    @BeforeEach
+    void setUp() {
+        languageService = new LanguageService();
+    }
+
+    @Test
+    @DisplayName("findAllLanguages 호출 시 전체 언어 목록을 DTO로 변환하여 반환한다")
+    void findAllLanguages_shouldReturnCorrectLanguageList() {
+        // given
+        int expectedSize = Language.values().length;
+
+        // when
+        List<LanguageResponse> actualLanguages = languageService.findAllLanguages();
+
+        // then
+        assertThat(actualLanguages).isNotNull();
+        assertThat(actualLanguages).hasSize(expectedSize);
+
+        // Language Enum의 모든 languageName이 DTO 리스트에 포함되어 있는지 확인
+        List<String> expectedNames = Arrays.stream(Language.values())
+                .map(Language::getLanguageName)
+                .toList();
+
+        assertThat(actualLanguages)
+                .extracting(LanguageResponse::languageName)
+                .containsExactlyInAnyOrderElementsOf(expectedNames);
+    }
+
+    @Test
+    @DisplayName("findAllLanguages가 반환한 리스트는 수정할 수 없다")
+    void findAllLanguages_shouldReturnUnmodifiableList() {
+        // given
+        List<LanguageResponse> actualLanguages = languageService.findAllLanguages();
+        LanguageResponse newLanguage = new LanguageResponse("Klingon"); // 임의의 새 언어
+
+        // when & then
+        // 리스트에 요소를 추가하려고 할 때 UnsupportedOperationException이 발생하는지 검증
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+                .isThrownBy(() -> actualLanguages.add(newLanguage));
+
+        // 리스트의 요소를 제거하려고 할 때도 동일하게 예외가 발생하는지 검증
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+                .isThrownBy(() -> actualLanguages.remove(0));
+    }
+
+    @Test
+    @DisplayName("findAllLanguages를 여러 번 호출해도 항상 동일한 인스턴스를 반환한다")
+    void findAllLanguages_shouldReturnSameInstanceOnMultipleCalls() {
+        // given & when
+        List<LanguageResponse> result1 = languageService.findAllLanguages();
+        List<LanguageResponse> result2 = languageService.findAllLanguages();
+
+        // then
+        // 두 결과가 내용만 같은 것(equals)이 아니라, 완전히 동일한 객체(인스턴스)인지 검증
+        assertThat(result1).isSameAs(result2);
+    }
+}


### PR DESCRIPTION
# 📄 Work Description

음식 메뉴를 다국어로 번역하고, 지원하는 언어 목록을 조회하는 기능을 구현했습니다. 외부 번역 API와의 연동을 위한 인프라를 구축하고, 관련 API 엔드포인트를 제공하여 클라이언트가 다양한 언어로 메뉴 정보를 볼 수 있는 기반을 마련했습니다.

-   **언어 조회 API 및 서비스 구현**
    `LanguageController`, `LanguageService`를 구현하여 지원하는 전체 언어 목록을 조회하는 `GET /language` API를 완성했습니다. `Enum` 데이터를 `static final` 리스트에 캐싱하여 응답 성능을 최적화했으며, DTO는 `record`를 사용하여 간결하게 정의했습니다.

-   **번역 기능 추상화 및 인프라 구축**
    `TranslationClient` 인터페이스를 통해 번역 기능을 추상화하고, Google Cloud Translate API를 사용하는 `GoogleTranslationClient`를 구현체로 추가했습니다. 이를 통해 향후 다른 번역 서비스로 쉽게 교체할 수 있는 유연한 구조를 마련했습니다.

-   **단위 테스트 작성 및 코드 안정성 확보**
    `LanguageService`에 대한 단위 테스트를 작성하여 코드의 신뢰성을 확보했습니다. 주요 검증 사항은 다음과 같습니다.
    -   `Language` Enum의 모든 항목이 DTO로 정확히 변환되는지 **(정확성, 완전성)**
    -   반환된 리스트가 수정 불가능(unmodifiable)한지 **(불변성)**
    -   여러 번 호출해도 동일한 인스턴스를 반환하는지 **(캐싱 동작)**

# 🤔 고민한 내용

1.  **번역 기능 제공자의 추상화**
    -   **고민:** 처음에는 번역이 필요한 서비스가 `GoogleTranslationClient` 구현체에 직접 의존하도록 설계할 수 있었습니다. 하지만 이는 향후 번역 API 제공처가 변경되거나(예: Papago API로 전환), 테스트 시 Mock 객체 사용을 어렵게 만드는 경직된 구조였습니다.
    -   **결정:** `TranslationClient`라는 인터페이스를 도입하여 서비스 계층이 구체적인 구현이 아닌 추상화에 의존하도록 설계했습니다 (의존성 역전 원칙, DIP). 이로 인해 서비스 코드의 변경 없이도 `GoogleTranslationClient`를 다른 `Provider`로 손쉽게 교체할 수 있게 되어, 시스템의 **유연성**과 **테스트 용이성**을  향상시켰습니다.

2.  **도메인 예외의 타입 안정성 강화**
    -   **고민:** 기존 `CurrencyException`은 생성자에서 상위 인터페이스인 `ErrorCode`를 받고 있었습니다. 이는 문법적으로 유연했지만, `new CurrencyException(UserErrorCode.LOGIN_FAILED)`처럼 논리적으로 맞지 않는 예외 생성을 막을 수 없다는 단점이 있었습니다.
    -   **결정:** 생성자의 파라미터 타입을 구체적인 `CurrencyErrorCode` Enum으로 변경했습니다. 이 리팩토링을 통해 해당 예외는 반드시 **자신과 관련된 에러 코드**하고만 생성되도록 컴파일러 수준에서 강제할 수 있게 되었습니다. 이는  코드의 **명확성과 안정성**을 높이는 더 나은 설계라고 판단했습니다.