### PR TITLE
feat: 메뉴판 이미지 분석 및 정보 보강 API 구현

### DIFF
--- a/src/main/java/foodiepass/server/currency/infra/GoogleFinanceRateProvider.java
+++ b/src/main/java/foodiepass/server/currency/infra/GoogleFinanceRateProvider.java
@@ -29,7 +29,7 @@ public class GoogleFinanceRateProvider implements ExchangeRateProvider {
     }
 
     @Override
-    @Cacheable(value = "exchangeRates", key = "#from.currencyCode + '::' + #to.currencyCode", unless = "#result == null")
+    @Cacheable(value = "exchangeRates", key = "#from.currencyCode + '::' + #to.currencyCode")
     public double getExchangeRate(final Currency from, final Currency to) {
         if (from.equals(to)) {
             return 1.0;
@@ -55,7 +55,7 @@ public class GoogleFinanceRateProvider implements ExchangeRateProvider {
     }
 
     @Override
-    @Cacheable(value = "exchangeRatesAsync", key = "#from.currencyCode + '::' + #to.currencyCode", unless = "#result == null")
+    @Cacheable(value = "exchangeRatesAsync", key = "#from.currencyCode + '::' + #to.currencyCode")
     public Mono<Double> getExchangeRateAsync(final Currency from, final Currency to) {
         return Mono.fromCallable(() -> getExchangeRate(from, to))
                 .subscribeOn(Schedulers.boundedElastic());

--- a/src/main/java/foodiepass/server/global/config/TranslationConfig.java
+++ b/src/main/java/foodiepass/server/global/config/TranslationConfig.java
@@ -2,7 +2,7 @@ package foodiepass.server.global.config;
 
 import com.google.cloud.translate.Translate;
 import foodiepass.server.language.infra.GoogleTranslationClient;
-import foodiepass.server.menu.domain.TranslationClient;
+import foodiepass.server.menu.application.port.out.TranslationClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/foodiepass/server/language/infra/GoogleTranslationClient.java
+++ b/src/main/java/foodiepass/server/language/infra/GoogleTranslationClient.java
@@ -3,15 +3,17 @@ package foodiepass.server.language.infra;
 import com.google.cloud.translate.Translate;
 import com.google.cloud.translate.TranslateException;
 import com.google.cloud.translate.Translation;
-import foodiepass.server.menu.domain.TranslationClient;
 import foodiepass.server.language.domain.Language;
 import foodiepass.server.language.exception.LanguageErrorCode;
 import foodiepass.server.language.exception.LanguageException;
+import foodiepass.server.menu.application.port.out.TranslationClient;
 import lombok.NonNull;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import static com.google.cloud.translate.Translate.TranslateOption.model;
 import static com.google.cloud.translate.Translate.TranslateOption.sourceLanguage;
@@ -53,5 +55,15 @@ public class GoogleTranslationClient implements TranslationClient {
         } catch (final TranslateException e) {
             throw new LanguageException(LanguageErrorCode.TRANSLATION_FAILED);
         }
+    }
+
+    @Override
+    public Mono<String> translateAsync(
+            @NonNull final Language from,
+            @NonNull final Language to,
+            @NonNull final String content
+    ) {
+        return Mono.fromCallable(() -> translate(from, to, content))
+                .subscribeOn(Schedulers.boundedElastic());
     }
 }

--- a/src/main/java/foodiepass/server/menu/api/MenuController.java
+++ b/src/main/java/foodiepass/server/menu/api/MenuController.java
@@ -1,0 +1,23 @@
+package foodiepass.server.menu.api;
+
+import foodiepass.server.menu.application.MenuService;
+import foodiepass.server.menu.dto.request.ReconfigureRequest;
+import foodiepass.server.menu.dto.response.ReconfigureResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/menu")
+public class MenuController {
+
+    private final MenuService menuService;
+
+    @PostMapping("/reconfigure")
+    public ReconfigureResponse reconfigure(@RequestBody final ReconfigureRequest request) {
+        return menuService.reconfigure(request);
+    }
+}

--- a/src/main/java/foodiepass/server/menu/application/MenuItemEnricher.java
+++ b/src/main/java/foodiepass/server/menu/application/MenuItemEnricher.java
@@ -5,15 +5,18 @@ import foodiepass.server.currency.domain.Currency;
 import foodiepass.server.language.domain.Language;
 import foodiepass.server.menu.application.port.out.FoodScrapper;
 import foodiepass.server.menu.application.port.out.TranslationClient;
+import foodiepass.server.menu.domain.FoodInfo;
 import foodiepass.server.menu.domain.MenuItem;
 import foodiepass.server.menu.dto.response.ReconfigureResponse.FoodItemResponse;
 import foodiepass.server.menu.dto.response.ReconfigureResponse.PriceInfoResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
 
+@Slf4j
 @Service
 public class MenuItemEnricher {
 
@@ -40,16 +43,28 @@ public class MenuItemEnricher {
             final Currency originCurrency,
             final Currency userCurrency
     ) {
-        Mono<String> engNameMono = translationClient.translateAsync(originLanguage, ENGLISH, menuItem.getName());
+        Mono<String> engNameMono = translationClient.translateAsync(originLanguage, ENGLISH, menuItem.getName())
+                .onErrorResume(e -> {
+                    log.warn("영문 번역 실패: '{}'. 원본 이름을 사용합니다.", menuItem.getName(), e);
+                    return Mono.just(menuItem.getName());
+                });
 
         return engNameMono.flatMap(engName ->
                 foodScraper.scrapAsync(List.of(engName))
                         .next()
+                        .onErrorResume(e -> {
+                            log.warn("스크래핑 실패: '{}'. 기본 FoodInfo를 사용합니다.", engName, e);
+                            return Mono.just(new FoodInfo(engName, "상세 정보를 불러올 수 없습니다.", "", ""));
+                        })
                         .flatMap(scrapedFoodInfo -> {
-                            Mono<String> translatedNameMono = translationClient.translateAsync(ENGLISH, userLanguage, scrapedFoodInfo.getName());
-                            Mono<String> translatedDescriptionMono = translationClient.translateAsync(ENGLISH, userLanguage, scrapedFoodInfo.getDescription());
+                            Mono<String> translatedNameMono = translationClient.translateAsync(ENGLISH, userLanguage, scrapedFoodInfo.getName())
+                                    .onErrorResume(e -> Mono.just(scrapedFoodInfo.getName()));
 
-                            Mono<PriceInfoResponse> priceInfoMono = currencyService.convertAndFormatAsync(menuItem.getPrice(), userCurrency);
+                            Mono<String> translatedDescriptionMono = translationClient.translateAsync(ENGLISH, userLanguage, scrapedFoodInfo.getDescription())
+                                    .onErrorResume(e -> Mono.just("상세 설명을 번역할 수 없습니다."));
+
+                            Mono<PriceInfoResponse> priceInfoMono = currencyService.convertAndFormatAsync(menuItem.getPrice(), userCurrency)
+                                    .onErrorResume(e -> Mono.just(new PriceInfoResponse("N/A", "N/A")));
 
                             return Mono.zip(translatedNameMono, translatedDescriptionMono, priceInfoMono)
                                     .map(tuple -> new FoodItemResponse(

--- a/src/main/java/foodiepass/server/menu/application/MenuItemEnricher.java
+++ b/src/main/java/foodiepass/server/menu/application/MenuItemEnricher.java
@@ -1,0 +1,65 @@
+package foodiepass.server.menu.application;
+
+import foodiepass.server.currency.application.CurrencyService;
+import foodiepass.server.currency.domain.Currency;
+import foodiepass.server.language.domain.Language;
+import foodiepass.server.menu.application.port.out.FoodScrapper;
+import foodiepass.server.menu.application.port.out.TranslationClient;
+import foodiepass.server.menu.domain.MenuItem;
+import foodiepass.server.menu.dto.response.ReconfigureResponse.FoodItemResponse;
+import foodiepass.server.menu.dto.response.ReconfigureResponse.PriceInfoResponse;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Service
+public class MenuItemEnricher {
+
+    private final FoodScrapper foodScraper;
+    private final TranslationClient translationClient;
+    private final CurrencyService currencyService;
+
+    private static final Language ENGLISH = Language.fromLanguageName("English");
+
+    public MenuItemEnricher(
+            @Qualifier("tasteAtlasFoodScrapper") FoodScrapper foodScraper,
+            TranslationClient translationClient,
+            CurrencyService currencyService
+    ) {
+        this.foodScraper = foodScraper;
+        this.translationClient = translationClient;
+        this.currencyService = currencyService;
+    }
+
+    public Mono<FoodItemResponse> enrichAsync(
+            final MenuItem menuItem,
+            final Language originLanguage,
+            final Language userLanguage,
+            final Currency originCurrency,
+            final Currency userCurrency
+    ) {
+        Mono<String> engNameMono = translationClient.translateAsync(originLanguage, ENGLISH, menuItem.getName());
+
+        return engNameMono.flatMap(engName ->
+                foodScraper.scrapAsync(List.of(engName))
+                        .next()
+                        .flatMap(scrapedFoodInfo -> {
+                            Mono<String> translatedNameMono = translationClient.translateAsync(ENGLISH, userLanguage, scrapedFoodInfo.getName());
+                            Mono<String> translatedDescriptionMono = translationClient.translateAsync(ENGLISH, userLanguage, scrapedFoodInfo.getDescription());
+
+                            Mono<PriceInfoResponse> priceInfoMono = currencyService.convertAndFormatAsync(menuItem.getPrice(), userCurrency);
+
+                            return Mono.zip(translatedNameMono, translatedDescriptionMono, priceInfoMono)
+                                    .map(tuple -> new FoodItemResponse(
+                                            menuItem.getName(),
+                                            tuple.getT1(),
+                                            tuple.getT2(),
+                                            scrapedFoodInfo.getImage(),
+                                            tuple.getT3()
+                                    ));
+                        })
+        );
+    }
+}

--- a/src/main/java/foodiepass/server/menu/application/MenuService.java
+++ b/src/main/java/foodiepass/server/menu/application/MenuService.java
@@ -1,0 +1,42 @@
+package foodiepass.server.menu.application;
+
+import foodiepass.server.currency.domain.Currency;
+import foodiepass.server.language.domain.Language;
+import foodiepass.server.menu.application.port.out.OcrReader;
+import foodiepass.server.menu.domain.MenuItem;
+import foodiepass.server.menu.dto.request.ReconfigureRequest;
+import foodiepass.server.menu.dto.response.ReconfigureResponse;
+import foodiepass.server.menu.dto.response.ReconfigureResponse.FoodItemResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MenuService {
+
+    private final OcrReader ocrReader;
+    private final MenuItemEnricher menuItemEnricher;
+
+    public ReconfigureResponse reconfigure(final ReconfigureRequest request) {
+        final Language originLanguage = Language.fromLanguageName(request.originLanguageName());
+        final Language userLanguage = Language.fromLanguageName(request.userLanguageName());
+        final Currency originCurrency = Currency.fromCurrencyName(request.originCurrencyName());
+        final Currency userCurrency = Currency.fromCurrencyName(request.userCurrencyName());
+
+        final List<MenuItem> menuItems = ocrReader.read(request.base64EncodedImage());
+
+        final List<FoodItemResponse> foodItemResponses = menuItems.parallelStream()
+                .map(menuItem -> menuItemEnricher.enrichAsync(
+                        menuItem,
+                        originLanguage,
+                        userLanguage,
+                        originCurrency,
+                        userCurrency
+                ).block())
+                .toList();
+
+        return new ReconfigureResponse(foodItemResponses);
+    }
+}

--- a/src/main/java/foodiepass/server/menu/domain/ExchangeRateProvider.java
+++ b/src/main/java/foodiepass/server/menu/domain/ExchangeRateProvider.java
@@ -1,7 +1,0 @@
-package foodiepass.server.menu.domain;
-
-import foodiepass.server.currency.domain.Currency;
-
-public interface ExchangeRateProvider {
-    Double getExchangeRate(final Currency from, final Currency to);
-}

--- a/src/main/java/foodiepass/server/menu/domain/TranslationClient.java
+++ b/src/main/java/foodiepass/server/menu/domain/TranslationClient.java
@@ -1,8 +1,0 @@
-package foodiepass.server.menu.domain;
-
-import foodiepass.server.language.domain.Language;
-import lombok.NonNull;
-
-public interface TranslationClient {
-  String translate(@NonNull final Language from, @NonNull final Language to, @NonNull final String content);
-}

--- a/src/main/java/foodiepass/server/menu/dto/request/ReconfigureRequest.java
+++ b/src/main/java/foodiepass/server/menu/dto/request/ReconfigureRequest.java
@@ -1,0 +1,10 @@
+package foodiepass.server.menu.dto.request;
+
+public record ReconfigureRequest(
+        String base64EncodedImage,
+        String originLanguageName,
+        String userLanguageName,
+        String originCurrencyName,
+        String userCurrencyName
+) {
+}

--- a/src/main/java/foodiepass/server/menu/dto/response/ReconfigureResponse.java
+++ b/src/main/java/foodiepass/server/menu/dto/response/ReconfigureResponse.java
@@ -1,0 +1,20 @@
+package foodiepass.server.menu.dto.response;
+
+import java.util.List;
+
+public record ReconfigureResponse(
+        List<FoodItemResponse> results
+) {
+    public record FoodItemResponse(
+            String originMenuName,
+            String translatedMenuName,
+            String description,
+            String image,
+            PriceInfoResponse priceInfo
+    ) {}
+
+    public record PriceInfoResponse(
+            String originPriceWithCurrencyUnit,
+            String userPriceWithCurrencyUnit
+    ) {}
+}

--- a/src/main/java/foodiepass/server/script/application/ScriptFactory.java
+++ b/src/main/java/foodiepass/server/script/application/ScriptFactory.java
@@ -1,7 +1,7 @@
 package foodiepass.server.script.application;
 
-import foodiepass.server.menu.domain.TranslationClient;
 import foodiepass.server.language.domain.Language;
+import foodiepass.server.menu.application.port.out.TranslationClient;
 import foodiepass.server.order.domain.OrderItem;
 import foodiepass.server.script.domain.Script;
 import jakarta.annotation.PostConstruct;

--- a/src/test/java/foodiepass/server/ServerApplicationTests.java
+++ b/src/test/java/foodiepass/server/ServerApplicationTests.java
@@ -1,17 +1,19 @@
 package foodiepass.server;
 
+import foodiepass.server.menu.application.port.out.OcrReader;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles; // import 추가
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-@ActiveProfiles("test") // "test" 프로파일을 활성화하여 application-test.yml을 로드합니다.
+@ActiveProfiles("test")
 @SpringBootTest
 class ServerApplicationTests {
 
+	@MockitoBean
+	private OcrReader ocrReader;
+
 	@Test
 	void contextLoads() {
-		// 이제 application-test.yml의 모든 설정값을 사용하여
-		// 애플리케이션 컨텍스트가 성공적으로 로드됩니다.
 	}
-
 }

--- a/src/test/java/foodiepass/server/currency/application/CurrencyServiceTest.java
+++ b/src/test/java/foodiepass/server/currency/application/CurrencyServiceTest.java
@@ -5,7 +5,7 @@ import foodiepass.server.currency.dto.request.CalculatePriceRequest;
 import foodiepass.server.currency.dto.response.CalculatePriceResponse;
 import foodiepass.server.currency.dto.response.CurrencyResponse;
 import foodiepass.server.currency.exception.CurrencyException;
-import foodiepass.server.menu.domain.ExchangeRateProvider;
+import foodiepass.server.menu.application.port.out.ExchangeRateProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/foodiepass/server/currency/application/CurrencyServiceTest.java
+++ b/src/test/java/foodiepass/server/currency/application/CurrencyServiceTest.java
@@ -1,11 +1,13 @@
 package foodiepass.server.currency.application;
 
+import foodiepass.server.common.price.domain.Price;
 import foodiepass.server.currency.domain.Currency;
 import foodiepass.server.currency.dto.request.CalculatePriceRequest;
 import foodiepass.server.currency.dto.response.CalculatePriceResponse;
 import foodiepass.server.currency.dto.response.CurrencyResponse;
 import foodiepass.server.currency.exception.CurrencyException;
 import foodiepass.server.menu.application.port.out.ExchangeRateProvider;
+import foodiepass.server.menu.dto.response.ReconfigureResponse.PriceInfoResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -13,6 +15,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -45,10 +49,32 @@ class CurrencyServiceTest {
         // then
         assertThat(responses).isNotNull();
         assertThat(responses.size()).isEqualTo(expectedSize);
-
         assertThat(responses)
                 .extracting(CurrencyResponse::currencyName)
                 .contains(Currency.SOUTH_KOREAN_WON.getCurrencyName());
+    }
+
+    @Test
+    @DisplayName("convertAndFormatAsync는 가격을 비동기적으로 변환하고 포맷팅한다")
+    void convertAndFormatAsync_shouldConvertAndFormatPrice() {
+        // given
+        Price originPrice = new Price(Currency.SOUTH_KOREAN_WON, new BigDecimal("1000"));
+        Currency userCurrency = Currency.JAPANESE_YEN;
+        double exchangeRate = 10.5;
+
+        given(exchangeRateProvider.getExchangeRateAsync(Currency.SOUTH_KOREAN_WON, userCurrency))
+                .willReturn(Mono.just(exchangeRate));
+
+        // when
+        Mono<PriceInfoResponse> result = currencyService.convertAndFormatAsync(originPrice, userCurrency);
+
+        // then
+        StepVerifier.create(result)
+                .expectNextMatches(priceInfo ->
+                        priceInfo.originPriceWithCurrencyUnit().contains("₩") &&
+                                priceInfo.userPriceWithCurrencyUnit().contains("¥")
+                )
+                .verifyComplete();
     }
 
     @Nested
@@ -74,12 +100,8 @@ class CurrencyServiceTest {
 
             // then
             assertThat(response).isNotNull();
-
-            // 원본 통화 총액 계산: 15.99 * 1 + 4.50 * 2 = 24.99
             assertThat(response.originTotalPrice().value()).isEqualByComparingTo("24.99");
             assertThat(response.originTotalPrice().currencyCode()).isEqualTo("USD");
-
-            // 사용자 통화 총액 계산: 24.99 * 1350.50 = 33749.995, 서비스 로직에 의해 33749.00으로 포맷팅
             assertThat(response.userTotalPrice().value()).isEqualByComparingTo("33749.00");
             assertThat(response.userTotalPrice().currencyCode()).isEqualTo("KRW");
         }

--- a/src/test/java/foodiepass/server/menu/api/MenuControllerTest.java
+++ b/src/test/java/foodiepass/server/menu/api/MenuControllerTest.java
@@ -1,0 +1,57 @@
+package foodiepass.server.menu.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import foodiepass.server.menu.application.MenuService;
+import foodiepass.server.menu.dto.request.ReconfigureRequest;
+import foodiepass.server.menu.dto.response.ReconfigureResponse;
+import foodiepass.server.menu.dto.response.ReconfigureResponse.FoodItemResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MenuController.class)
+class MenuControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private MenuService menuService;
+
+    @Test
+    @DisplayName("POST /menu/reconfigure 요청 시 메뉴 재구성 결과를 성공적으로 반환한다")
+    void reconfigure_shouldReturnReconfiguredMenu() throws Exception {
+        // given
+        ReconfigureRequest request = new ReconfigureRequest(
+                "base64image", "Korean", "English", "South Korean Won", "US Dollar"
+        );
+
+        FoodItemResponse foodItemResponse = new FoodItemResponse("김치찌개", "Kimchi Stew", "Spicy stew", "image.jpg", null);
+        ReconfigureResponse mockResponse = new ReconfigureResponse(Collections.singletonList(foodItemResponse));
+
+        when(menuService.reconfigure(any(ReconfigureRequest.class))).thenReturn(mockResponse);
+
+        // when & then
+        mockMvc.perform(post("/menu/reconfigure")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.results[0].originMenuName").value("김치찌개"))
+                .andExpect(jsonPath("$.result.results[0].translatedMenuName").value("Kimchi Stew"));
+    }
+}

--- a/src/test/java/foodiepass/server/menu/application/MenuItemEnricherTest.java
+++ b/src/test/java/foodiepass/server/menu/application/MenuItemEnricherTest.java
@@ -1,0 +1,89 @@
+package foodiepass.server.menu.application;
+
+import foodiepass.server.common.price.domain.Price;
+import foodiepass.server.currency.application.CurrencyService;
+import foodiepass.server.currency.domain.Currency;
+import foodiepass.server.language.domain.Language;
+import foodiepass.server.menu.application.port.out.FoodScrapper;
+import foodiepass.server.menu.application.port.out.TranslationClient;
+import foodiepass.server.menu.domain.FoodInfo;
+import foodiepass.server.menu.domain.MenuItem;
+import foodiepass.server.menu.dto.response.ReconfigureResponse.FoodItemResponse;
+import foodiepass.server.menu.dto.response.ReconfigureResponse.PriceInfoResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MenuItemEnricherTest {
+
+    private MenuItemEnricher menuItemEnricher;
+
+    @Mock
+    private FoodScrapper foodScraper;
+    @Mock
+    private TranslationClient translationClient;
+    @Mock
+    private CurrencyService currencyService;
+
+    @BeforeEach
+    void setUp() {
+        menuItemEnricher = new MenuItemEnricher(foodScraper, translationClient, currencyService);
+    }
+
+    @Test
+    @DisplayName("메뉴 아이템 정보를 비동기적으로 보강하여 FoodItemResponse를 반환한다")
+    void enrichAsync_shouldEnrichMenuItemAndReturnResponse() {
+        // given
+        Price originalPrice = new Price(Currency.SOUTH_KOREAN_WON, new BigDecimal("13000"));
+        FoodInfo dummyFoodInfo = new FoodInfo("Kimchi Jjigae", "initial", "initial.jpg", "initial_preview.jpg");
+        MenuItem menuItem = new MenuItem("Kimchi Jjigae", originalPrice, dummyFoodInfo);
+
+        Language originLanguage = Language.fromLanguageName("Korean");
+        Language userLanguage = Language.fromLanguageName("Japanese");
+        Currency originCurrency = Currency.SOUTH_KOREAN_WON;
+        Currency userCurrency = Currency.JAPANESE_YEN;
+
+        FoodInfo scrapedFoodInfo = new FoodInfo("Kimchi Stew", "Spicy kimchi stew with pork", "image.jpg", "preview.jpg");
+        PriceInfoResponse priceInfoResponse = new PriceInfoResponse("₩13,000", "¥1,300");
+
+        // Mocking
+        when(translationClient.translateAsync(originLanguage, Language.fromLanguageName("English"), "Kimchi Jjigae"))
+                .thenReturn(Mono.just("Kimchi Stew"));
+        when(foodScraper.scrapAsync(List.of("Kimchi Stew")))
+                .thenReturn(Flux.just(scrapedFoodInfo));
+        when(translationClient.translateAsync(Language.fromLanguageName("English"), userLanguage, "Kimchi Stew"))
+                .thenReturn(Mono.just("キムチチゲ"));
+        when(translationClient.translateAsync(Language.fromLanguageName("English"), userLanguage, "Spicy kimchi stew with pork"))
+                .thenReturn(Mono.just("豚肉入りの辛いキムチチゲ"));
+        when(currencyService.convertAndFormatAsync(any(Price.class), eq(userCurrency)))
+                .thenReturn(Mono.just(priceInfoResponse));
+
+        // when
+        Mono<FoodItemResponse> result = menuItemEnricher.enrichAsync(menuItem, originLanguage, userLanguage, originCurrency, userCurrency);
+
+        // then
+        StepVerifier.create(result)
+                .expectNextMatches(response ->
+                        response.originMenuName().equals("Kimchi Jjigae") &&
+                                response.translatedMenuName().equals("キムチチゲ") &&
+                                response.description().equals("豚肉入りの辛いキムチチゲ") &&
+                                response.image().equals("image.jpg") &&
+                                response.priceInfo().equals(priceInfoResponse)
+                )
+                .verifyComplete();
+    }
+}

--- a/src/test/java/foodiepass/server/menu/application/MenuServiceTest.java
+++ b/src/test/java/foodiepass/server/menu/application/MenuServiceTest.java
@@ -1,0 +1,73 @@
+package foodiepass.server.menu.application;
+
+import foodiepass.server.common.price.domain.Price;
+import foodiepass.server.currency.domain.Currency;
+import foodiepass.server.menu.application.port.out.OcrReader;
+import foodiepass.server.menu.domain.FoodInfo;
+import foodiepass.server.menu.domain.MenuItem;
+import foodiepass.server.menu.dto.request.ReconfigureRequest;
+import foodiepass.server.menu.dto.response.ReconfigureResponse;
+import foodiepass.server.menu.dto.response.ReconfigureResponse.FoodItemResponse;
+import foodiepass.server.menu.dto.response.ReconfigureResponse.PriceInfoResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MenuServiceTest {
+
+    @InjectMocks
+    private MenuService menuService;
+
+    @Mock
+    private OcrReader ocrReader;
+    @Mock
+    private MenuItemEnricher menuItemEnricher;
+
+    @Test
+    @DisplayName("메뉴 재구성 요청 시 OCR과 정보 보강을 거쳐 응답을 반환한다")
+    void reconfigure_shouldProcessOcrAndEnrichment() {
+        // given
+        ReconfigureRequest request = new ReconfigureRequest(
+                "base64image",
+                "Korean",
+                "English",
+                Currency.SOUTH_KOREAN_WON.getCurrencyName(),
+                Currency.UNITED_STATES_DOLLAR.getCurrencyName()
+        );
+
+        FoodInfo dummyFoodInfo = new FoodInfo("김치찌개", "dummy", "dummy.jpg", "dummy.jpg");
+        MenuItem menuItem1 = new MenuItem("김치찌개", new Price(Currency.SOUTH_KOREAN_WON, new BigDecimal("8000")), dummyFoodInfo);
+        List<MenuItem> ocrResult = List.of(menuItem1);
+
+        FoodItemResponse enrichedItem1 = new FoodItemResponse("김치찌개", "Kimchi Stew", "Spicy stew", "kimchi.jpg", new PriceInfoResponse("₩8,000", "$6.00"));
+
+        // Mocking
+        when(ocrReader.read(request.base64EncodedImage())).thenReturn(ocrResult);
+        when(menuItemEnricher.enrichAsync(eq(menuItem1), any(), any(), any(), any())).thenReturn(Mono.just(enrichedItem1));
+
+        // when
+        ReconfigureResponse response = menuService.reconfigure(request);
+
+        // then
+        assertThat(response.results()).hasSize(1);
+        assertThat(response.results().get(0)).isEqualTo(enrichedItem1);
+
+        verify(ocrReader, times(1)).read(request.base64EncodedImage());
+        verify(menuItemEnricher, times(1)).enrichAsync(any(), any(), any(), any(), any());
+    }
+}

--- a/src/test/java/foodiepass/server/script/application/ScriptFactoryTest.java
+++ b/src/test/java/foodiepass/server/script/application/ScriptFactoryTest.java
@@ -1,9 +1,9 @@
 package foodiepass.server.script.application;
 
 import foodiepass.server.common.price.domain.Price;
+import foodiepass.server.menu.application.port.out.TranslationClient;
 import foodiepass.server.menu.domain.FoodInfo;
 import foodiepass.server.menu.domain.MenuItem;
-import foodiepass.server.menu.domain.TranslationClient;
 import foodiepass.server.language.domain.Language;
 import foodiepass.server.order.domain.OrderItem;
 import foodiepass.server.script.domain.Script;


### PR DESCRIPTION
# 📄 Work Description

메뉴판 이미지(OCR)나 음식 이름을 기반으로 메뉴 정보를 분석하고, 외부 소스로부터 상세 정보를 스크래핑하여 보강하는 기능을 구현했습니다. 이 기능은 OCR, 비동기 번역 및 환율 변환, 외부 정보 스크래핑을 조합하여 사용자에게 풍부한 메뉴 정보를 제공합니다.

**1. 메뉴 분석 API 및 비동기 서비스 구현**

  - `MenuController`를 통해 `POST /menu/reconfigure` API 엔드포인트를 구현했습니다.
  - `MenuService`는 OCR, 정보 보강 등 전체 메뉴 분석 과정을 오케스트레이션하는 역할을 담당합니다.
  - `MenuItemEnricher`는 단일 메뉴 아이템에 대한 정보 보강(번역, 스크래핑, 가격 변환) 로직을 비동기(`Mono`)로 처리합니다. `Mono.zip`을 사용하여 여러 외부 API 호출을 병렬로 처리하고 조합하여 성능을 최적화했습니다.

**2. 비동기 인프라 전환 및 포트(Port) 재구성**

  - 기존 동기 방식의 `ExchangeRateProvider`, `TranslationClient` 인터페이스를 `application/port/out` 패키지로 이동시켜 **헥사고날 아키텍처** 구조를 적용했습니다.
  - 각 인터페이스에 비동기 방식의 `...Async` 메서드를 추가하고, `GoogleFinanceRateProvider`, `GoogleTranslationClient` 구현체에 `Mono`를 반환하는 비동기 로직을 구현하여 전체 시스템이 논블로킹(non-blocking)으로 동작할 수 있는 기반을 마련했습니다.

# 🤔 고민한 내용

**1. 다중 I/O 작업의 동시성 처리와 성능 최적화**

  - **고민**: 메뉴 아이템 하나를 보강하는 과정은 `1) 메뉴명 번역 → 2) 번역된 이름으로 정보 스크래핑 → 3) 스크래핑된 이름/설명 번역 + 4) 가격 정보 환율 변환` 등 다수의 네트워크 I/O를 필요로 합니다. 이 작업들을 순차적으로 동기 처리할 경우, 각 요청의 지연 시간이 합산되어 사용자 경험을 심각하게 저해할 수 있었습니다.
  - **결정**: Project Reactor(`Mono`, `Flux`)를 도입하여 전체 정보 보강 과정을 비동기 파이프라인으로 설계했습니다. 특히 3번과 4번 과정은 서로 의존성이 없으므로, `Mono.zip`을 사용하여 두 개의 번역 API 호출과 환율 변환 API 호출을 **병렬로 동시에 처리**하도록 구현했습니다. 이를 통해 독립적인 I/O 작업들이 서로를 기다리지 않게 되어 전체 응답 시간을 크게 단축하고 성능을 최적화했습니다.

**2. 블로킹(Blocking) API와 논블로킹(Non-blocking) 서비스의 연결점**

  - **고민**: `MenuItemEnricher`의 핵심 로직은 `Mono`를 반환하는 완전한 논블로킹 코드이지만, `MenuController`는 전통적인 Spring MVC(Servlet) 기반의 블로킹 방식으로 동작합니다. 논블로킹 서비스의 결과를 블로킹 컨트롤러에서 어떻게 처리해야 할지 결정이 필요했습니다.
  - **결정**: 현재 구현 단계에서는 컨트롤러-서비스 경계의 복잡성을 최소화하기 위해, `MenuService`에서 `parallelStream()`을 사용하되 최종적으로 `.block()`을 호출하여 비동기 작업의 결과를 동기적으로 기다리는 방식을 채택했습니다. 하지만 이 지점이 웹 서버의 스레드를 점유하는 잠재적인 성능 병목 지점임을 인지하고 있습니다. 향후 트래픽 증가 시, `WebFlux`를 도입하여 컨트롤러까지 완전한 End-to-End 논블로킹 파이프라인으로 전환하는 리팩토링을 고려하고자 합니다.