### PR TITLE
refactor : 전체 요청 처리 파이프라인의 블로킹(Blocking) 코드 제거 및 완전한 비동기 리액티브 스택으로 전환

### DIFF
--- a/src/main/java/foodiepass/server/currency/api/CurrencyController.java
+++ b/src/main/java/foodiepass/server/currency/api/CurrencyController.java
@@ -8,25 +8,27 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/currency")
 public class CurrencyController {
 
     private final CurrencyService currencyService;
 
-    @GetMapping("/currency")
     public List<CurrencyResponse> getCurrencies() {
         return currencyService.findAllCurrencies();
     }
 
-    @PostMapping("/currency/calculate")
-    public CalculatePriceResponse calculateTotalPrice(
+    @PostMapping("/calculate")
+    public Mono<CalculatePriceResponse> calculateTotalPrice(
             @RequestBody final CalculatePriceRequest calculatePriceRequest
     ) {
-        return currencyService.calculateOrdersPrice(calculatePriceRequest);
+        return currencyService.calculateOrdersPriceAsync(calculatePriceRequest);
     }
 }

--- a/src/main/java/foodiepass/server/currency/api/CurrencyController.java
+++ b/src/main/java/foodiepass/server/currency/api/CurrencyController.java
@@ -21,8 +21,9 @@ public class CurrencyController {
 
     private final CurrencyService currencyService;
 
-    public List<CurrencyResponse> getCurrencies() {
-        return currencyService.findAllCurrencies();
+    @GetMapping
+    public Mono<List<CurrencyResponse>> getCurrencies() {
+        return Mono.just(currencyService.findAllCurrencies());
     }
 
     @PostMapping("/calculate")

--- a/src/main/java/foodiepass/server/menu/api/MenuController.java
+++ b/src/main/java/foodiepass/server/menu/api/MenuController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,7 +18,7 @@ public class MenuController {
     private final MenuService menuService;
 
     @PostMapping("/reconfigure")
-    public ReconfigureResponse reconfigure(@RequestBody final ReconfigureRequest request) {
+    public Mono<ReconfigureResponse> reconfigure(@RequestBody final ReconfigureRequest request) {
         return menuService.reconfigure(request);
     }
 }

--- a/src/main/java/foodiepass/server/script/api/ScriptController.java
+++ b/src/main/java/foodiepass/server/script/api/ScriptController.java
@@ -6,16 +6,19 @@ import foodiepass.server.script.dto.response.ScriptResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/scripts")
 public class ScriptController {
 
     private final ScriptService scriptService;
 
-    @PostMapping("/scripts/generate")
-    public ScriptResponse generateScript(
+    @PostMapping("/generate")
+    public Mono<ScriptResponse> generateScript(
             @RequestBody final ScriptGenerateRequest request
     ) {
         return scriptService.generateScript(request);

--- a/src/test/java/foodiepass/server/menu/api/MenuControllerTest.java
+++ b/src/test/java/foodiepass/server/menu/api/MenuControllerTest.java
@@ -17,6 +17,7 @@ import reactor.core.publisher.Mono;
 
 import java.util.Collections;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -39,7 +40,7 @@ class MenuControllerTest {
 
     @Test
     @DisplayName("POST /menu/reconfigure 요청 시 메뉴 재구성 결과를 성공적으로 반환한다")
-    void reconfigure_shouldReturnReconfiguredMenu() throws Exception {
+    void reconfigure_shouldReturnReconfiguredMenu() {
         // given
         ReconfigureRequest request = new ReconfigureRequest(
                 "base64image", "Korean", "English", "KRW", "USD"
@@ -60,8 +61,8 @@ class MenuControllerTest {
                 .expectStatus().isOk()
                 .expectBody(ReconfigureResponse.class)
                 .value(response -> {
-                    assert response.results().get(0).originMenuName().equals("김치찌개");
-                    assert response.results().get(0).translatedMenuName().equals("Kimchi Stew");
+                    assertThat(response.results().get(0).originMenuName()).isEqualTo("김치찌개");
+                    assertThat(response.results().get(0).translatedMenuName()).isEqualTo("Kimchi Stew");
                 });
     }
 }


### PR DESCRIPTION
# 📄 **Work Description**

전체 요청 처리 파이프라인을 완전한 논블로킹(Non-blocking) 리액티브 스택으로 전환했습니다. `MenuService`를 포함하여 `CurrencyService`, `ScriptService` 등 주요 서비스들의 블로킹 코드를 제거하고, 컨트롤러 단까지 `Mono`와 `Flux`를 사용하여 End-to-End 비동기 통신을 구현했습니다.

1.  **`.block()` 제거 및 완전 비동기 파이프라인 전환**
    -   `MenuService`에서 메뉴 아이템을 동기적으로 처리하던 `.block()` 호출을 제거하고, `Flux.flatMap()`을 사용하여 모든 과정을 논블로킹으로 리팩토링했습니다.
    -   `MenuController`, `CurrencyController`, `ScriptController`의 API 엔드포인트가 `Mono`를 직접 반환하도록 수정하여, WebFlux 기반의 완전한 리액티브 파이프라인을 완성했습니다.

2.  **주요 도메인 서비스의 비동기 리팩토링**
    -   `CurrencyService`와 `ScriptService` 역시 내부 로직을 `Mono` 기반의 비동기 파이프라인으로 전면 재구성하여, 시스템 전반에 걸쳐 일관된 논블로킹 아키텍처를 적용했습니다.
    -   특히 `ScriptFactory`의 접두사(prefix) 캐싱 로직을 비동기 환경에 맞게 개선하여, 캐시된 데이터가 없을 경우에만 논블로킹으로 API를 호출하도록 최적화했습니다.

3.  **리액티브 테스트 환경 전환**
    -   전통적인 Servlet 기반의 `MockMvc` 대신, 리액티브 스택을 테스트하기 위한 `WebTestClient`를 도입하여 논블로킹 컨트롤러의 동작을 정확하게 검증했습니다.

# 🤔 **고민한 내용**

1.  **리액티브 파이프라인의 기술 부채 해결**
    -   **고민:** 이전 PR(#26)에서는 컨트롤러-서비스 경계의 복잡성을 줄이고자 `MenuService`에서 의도적으로 `.block()`을 사용하여 동기적으로 결과를 반환했습니다. 이는 리액티브 스트림의 이점을 온전히 활용하지 못하고 웹 서버의 스레드를 점유하는 **잠재적인 성능 병목 지점**이라는 기술 부채로 남아있었습니다.
    -   **결정:** 이번 리팩토링을 통해 이 기술 부채를 해결하는 것을 최우선 목표로 삼았습니다. 모든 서비스의 `.block()` 코드를 제거하고, `flatMap`, `map` 등의 리액티브 연산자를 사용하여 **데이터 스트림을 처음부터 끝까지 논블로킹으로 처리**하도록 파이프라인을 재설계했습니다. 이를 통해 Netty 이벤트 루프의 장점을 극대화하고, 적은 스레드로 높은 동시성을 처리할 수 있는 확장성 높은 구조를 완성했습니다.