### PR TITLE
feat: 비동기 처리 도입을 통한 성능 개선 및 테스트 환경 구축

### DIFF
--- a/reconfigure-menu-load-test.js
+++ b/reconfigure-menu-load-test.js
@@ -1,0 +1,40 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+    stages: [
+        { duration: '30s', target: 50 },
+        { duration: '1m', target: 50 },
+        { duration: '10s', target: 0 },
+    ],
+    thresholds: {
+        http_req_failed: ['rate<0.01'],
+        http_req_duration: ['p(95)<2000'],
+    },
+};
+
+const payload = JSON.stringify({
+    base64EncodedImage: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+    originLanguageName: 'Korean',
+    userLanguageName: 'English',
+    originCurrencyName: 'South Korean won',
+    userCurrencyName: 'United States Dollar',
+});
+
+const params = {
+    headers: {
+        'Content-Type': 'application/json',
+    },
+};
+
+export default function () {
+    const url = 'http://localhost:8080/menu/reconfigure';
+
+    const res = http.post(url, payload, params);
+
+    check(res, {
+        'status is 200': (r) => r.status === 200,
+    });
+
+    sleep(1);
+}

--- a/src/main/java/foodiepass/server/global/config/GoogleCloudConfig.java
+++ b/src/main/java/foodiepass/server/global/config/GoogleCloudConfig.java
@@ -14,7 +14,7 @@ import org.springframework.core.io.ClassPathResource;
 import java.io.IOException;
 
 @Configuration
-@Profile("!performance-test")
+@Profile(ProfileConstants.NOT_PERFORMANCE_TEST)
 public class GoogleCloudConfig {
 
     @Bean

--- a/src/main/java/foodiepass/server/global/config/GoogleCloudConfig.java
+++ b/src/main/java/foodiepass/server/global/config/GoogleCloudConfig.java
@@ -8,11 +8,13 @@ import com.google.cloud.vertexai.VertexAI;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.ClassPathResource;
 
 import java.io.IOException;
 
 @Configuration
+@Profile("!performance-test")
 public class GoogleCloudConfig {
 
     @Bean

--- a/src/main/java/foodiepass/server/global/config/ProfileConstants.java
+++ b/src/main/java/foodiepass/server/global/config/ProfileConstants.java
@@ -1,0 +1,9 @@
+package foodiepass.server.global.config;
+
+public final class ProfileConstants {
+    private ProfileConstants() {}
+
+    public static final String PERFORMANCE_TEST = "performance-test";
+    public static final String NOT_PERFORMANCE_TEST = "!" + PERFORMANCE_TEST;
+    public static final String NOT_TEST_AND_NOT_PERFORMANCE_TEST = "!test & !" + PERFORMANCE_TEST;
+}

--- a/src/main/java/foodiepass/server/global/config/TranslationConfig.java
+++ b/src/main/java/foodiepass/server/global/config/TranslationConfig.java
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 
 @Configuration
-@Profile("!performance-test")
+@Profile(ProfileConstants.NOT_PERFORMANCE_TEST)
 public class TranslationConfig {
 
     @Bean

--- a/src/main/java/foodiepass/server/global/config/TranslationConfig.java
+++ b/src/main/java/foodiepass/server/global/config/TranslationConfig.java
@@ -7,8 +7,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 
 @Configuration
+@Profile("!performance-test")
 public class TranslationConfig {
 
     @Bean

--- a/src/main/java/foodiepass/server/global/config/mocks/MockFoodScrapper.java
+++ b/src/main/java/foodiepass/server/global/config/mocks/MockFoodScrapper.java
@@ -1,0 +1,30 @@
+package foodiepass.server.global.config.mocks;
+
+import foodiepass.server.menu.application.port.out.FoodScrapper;
+import foodiepass.server.menu.domain.FoodInfo;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+@Profile("performance-test")
+public class MockFoodScrapper implements FoodScrapper {
+
+    private static final Map<String, FoodInfo> MOCK_DATA = Map.of(
+            "김치찌개", new FoodInfo("김치찌개", "매콤하고 맛있는 김치찌개", "mock_kimchi.jpg", "mock_kimchi_preview.jpg"),
+            "된장찌개", new FoodInfo("된장찌개", "구수한 한국의 맛 된장찌개", "mock_doenjang.jpg", "mock_doenjang_preview.jpg"),
+            "제육볶음", new FoodInfo("제육볶음", "매콤달콤한 돼지고기 볶음", "mock_jeyuk.jpg", "mock_jeyuk_preview.jpg")
+    );
+
+    @Override
+    public Flux<FoodInfo> scrapAsync(final List<String> foodNames) {
+        List<FoodInfo> results = foodNames.stream()
+                .map(name -> MOCK_DATA.getOrDefault(name, new FoodInfo(name, "설명 없음", "default.jpg", "default_preview.jpg")))
+                .collect(Collectors.toList());
+        return Flux.fromIterable(results);
+    }
+}

--- a/src/main/java/foodiepass/server/global/config/mocks/MockOcrReader.java
+++ b/src/main/java/foodiepass/server/global/config/mocks/MockOcrReader.java
@@ -1,0 +1,25 @@
+package foodiepass.server.global.config.mocks;
+
+import foodiepass.server.common.price.domain.Price;
+import foodiepass.server.currency.domain.Currency;
+import foodiepass.server.menu.application.port.out.OcrReader;
+import foodiepass.server.menu.domain.MenuItem;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Component
+@Profile("performance-test")
+public class MockOcrReader implements OcrReader {
+
+    @Override
+    public List<MenuItem> read(final String base64encodedImage) {
+        return List.of(
+                new MenuItem("김치찌개", new Price(Currency.SOUTH_KOREAN_WON, new BigDecimal("8000")), null),
+                new MenuItem("된장찌개", new Price(Currency.SOUTH_KOREAN_WON, new BigDecimal("7000")), null),
+                new MenuItem("제육볶음", new Price(Currency.SOUTH_KOREAN_WON, new BigDecimal("9000")), null)
+        );
+    }
+}

--- a/src/main/java/foodiepass/server/global/config/mocks/MockTranslationClient.java
+++ b/src/main/java/foodiepass/server/global/config/mocks/MockTranslationClient.java
@@ -1,0 +1,25 @@
+package foodiepass.server.global.config.mocks;
+
+import foodiepass.server.language.domain.Language;
+import foodiepass.server.menu.application.port.out.TranslationClient;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Component
+@Profile("performance-test")
+public class MockTranslationClient implements TranslationClient {
+
+    @Override
+    public Mono<String> translateAsync(Language source, Language target, String text) {
+        return Mono.just(text);
+    }
+
+    @Override
+    public Flux<String> translateAsync(Language source, Language target, List<String> texts) {
+        return Flux.fromIterable(texts);
+    }
+}

--- a/src/main/java/foodiepass/server/language/infra/GoogleTranslationClient.java
+++ b/src/main/java/foodiepass/server/language/infra/GoogleTranslationClient.java
@@ -7,19 +7,24 @@ import foodiepass.server.language.domain.Language;
 import foodiepass.server.language.exception.LanguageErrorCode;
 import foodiepass.server.language.exception.LanguageException;
 import foodiepass.server.menu.application.port.out.TranslationClient;
-import lombok.NonNull;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cache.annotation.Cacheable;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.google.cloud.translate.Translate.TranslateOption.model;
 import static com.google.cloud.translate.Translate.TranslateOption.sourceLanguage;
 import static com.google.cloud.translate.Translate.TranslateOption.targetLanguage;
 
 @Component
+@Profile("!performance-test")
 public class GoogleTranslationClient implements TranslationClient {
 
     private final Translate translate;
@@ -34,36 +39,49 @@ public class GoogleTranslationClient implements TranslationClient {
     }
 
     @Override
-    @Cacheable(cacheNames = "translations", key = "{#from.name(), #to.name(), #content}")
-    public String translate(
-            @NonNull final Language from,
-            @NonNull final Language to,
-            @NonNull final String content
-    ) {
-        if (!StringUtils.hasText(content) || from.equals(to)) {
-            return content;
+    public Mono<String> translateAsync(Language source, Language target, String text) {
+        if (!StringUtils.hasText(text) || source.equals(target)) {
+            return Mono.just(text);
         }
 
-        try {
-            final Translation translation = translate.translate(
-                    content,
-                    sourceLanguage(from.getLanguageCode()),
-                    targetLanguage(to.getLanguageCode()),
-                    model(translationModel)
-            );
-            return translation.getTranslatedText();
-        } catch (final TranslateException e) {
-            throw new LanguageException(LanguageErrorCode.TRANSLATION_FAILED);
-        }
+        return Mono.fromCallable(() -> {
+                    try {
+                        Translation translation = translate.translate(
+                                text,
+                                sourceLanguage(source.getLanguageCode()),
+                                targetLanguage(target.getLanguageCode()),
+                                model(translationModel)
+                        );
+                        return translation.getTranslatedText();
+                    } catch (TranslateException e) {
+                        throw new LanguageException(LanguageErrorCode.TRANSLATION_FAILED);
+                    }
+                })
+                .subscribeOn(Schedulers.boundedElastic());
     }
 
     @Override
-    public Mono<String> translateAsync(
-            @NonNull final Language from,
-            @NonNull final Language to,
-            @NonNull final String content
-    ) {
-        return Mono.fromCallable(() -> translate(from, to, content))
-                .subscribeOn(Schedulers.boundedElastic());
+    public Flux<String> translateAsync(Language source, Language target, List<String> texts) {
+        if (CollectionUtils.isEmpty(texts) || source.equals(target)) {
+            return Flux.fromIterable(texts);
+        }
+
+        return Mono.fromCallable(() -> {
+                    try {
+                        List<Translation> translations = translate.translate(
+                                texts,
+                                sourceLanguage(source.getLanguageCode()),
+                                targetLanguage(target.getLanguageCode()),
+                                model(translationModel)
+                        );
+                        return translations.stream()
+                                .map(Translation::getTranslatedText)
+                                .collect(Collectors.toList());
+                    } catch (TranslateException e) {
+                        throw new LanguageException(LanguageErrorCode.TRANSLATION_FAILED);
+                    }
+                })
+                .subscribeOn(Schedulers.boundedElastic())
+                .flatMapMany(Flux::fromIterable);
     }
 }

--- a/src/main/java/foodiepass/server/language/infra/GoogleTranslationClient.java
+++ b/src/main/java/foodiepass/server/language/infra/GoogleTranslationClient.java
@@ -3,6 +3,7 @@ package foodiepass.server.language.infra;
 import com.google.cloud.translate.Translate;
 import com.google.cloud.translate.TranslateException;
 import com.google.cloud.translate.Translation;
+import foodiepass.server.global.config.ProfileConstants;
 import foodiepass.server.language.domain.Language;
 import foodiepass.server.language.exception.LanguageErrorCode;
 import foodiepass.server.language.exception.LanguageException;
@@ -24,7 +25,7 @@ import static com.google.cloud.translate.Translate.TranslateOption.sourceLanguag
 import static com.google.cloud.translate.Translate.TranslateOption.targetLanguage;
 
 @Component
-@Profile("!performance-test")
+@Profile(ProfileConstants.NOT_PERFORMANCE_TEST)
 public class GoogleTranslationClient implements TranslationClient {
 
     private final Translate translate;

--- a/src/main/java/foodiepass/server/menu/application/MenuItemEnricher.java
+++ b/src/main/java/foodiepass/server/menu/application/MenuItemEnricher.java
@@ -10,7 +10,6 @@ import foodiepass.server.menu.domain.MenuItem;
 import foodiepass.server.menu.dto.response.ReconfigureResponse.FoodItemResponse;
 import foodiepass.server.menu.dto.response.ReconfigureResponse.PriceInfoResponse;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
@@ -27,7 +26,7 @@ public class MenuItemEnricher {
     private static final Language ENGLISH = Language.fromLanguageName("English");
 
     public MenuItemEnricher(
-            @Qualifier("tasteAtlasFoodScrapper") FoodScrapper foodScraper,
+            FoodScrapper foodScraper,
             TranslationClient translationClient,
             CurrencyService currencyService
     ) {

--- a/src/main/java/foodiepass/server/menu/infra/scraper/gemini/GeminiClient.java
+++ b/src/main/java/foodiepass/server/menu/infra/scraper/gemini/GeminiClient.java
@@ -9,12 +9,14 @@ import com.google.protobuf.ByteString;
 import foodiepass.server.menu.infra.exception.GeminiErrorCode;
 import foodiepass.server.menu.infra.exception.GeminiException;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.Optional;
 
 @Component
+@Profile("!performance-test")
 public class GeminiClient {
 
     private final GenerativeModel multimodalModel;

--- a/src/main/java/foodiepass/server/menu/infra/scraper/gemini/GeminiClient.java
+++ b/src/main/java/foodiepass/server/menu/infra/scraper/gemini/GeminiClient.java
@@ -6,6 +6,7 @@ import com.google.cloud.vertexai.generativeai.ContentMaker;
 import com.google.cloud.vertexai.generativeai.GenerativeModel;
 import com.google.cloud.vertexai.generativeai.PartMaker;
 import com.google.protobuf.ByteString;
+import foodiepass.server.global.config.ProfileConstants;
 import foodiepass.server.menu.infra.exception.GeminiErrorCode;
 import foodiepass.server.menu.infra.exception.GeminiException;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,7 +17,7 @@ import java.io.IOException;
 import java.util.Optional;
 
 @Component
-@Profile("!performance-test")
+@Profile(ProfileConstants.NOT_PERFORMANCE_TEST)
 public class GeminiClient {
 
     private final GenerativeModel multimodalModel;

--- a/src/main/java/foodiepass/server/menu/infra/scraper/gemini/GeminiFoodScrapper.java
+++ b/src/main/java/foodiepass/server/menu/infra/scraper/gemini/GeminiFoodScrapper.java
@@ -7,6 +7,8 @@ import foodiepass.server.menu.domain.FoodInfo;
 import foodiepass.server.menu.infra.exception.GeminiErrorCode;
 import foodiepass.server.menu.infra.exception.GeminiException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -16,7 +18,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-@Component
+@Component("geminiFoodScrapper")
+@Primary
+@Profile("!performance-test")
 @RequiredArgsConstructor
 public class GeminiFoodScrapper implements FoodScrapper {
 

--- a/src/main/java/foodiepass/server/menu/infra/scraper/gemini/GeminiFoodScrapper.java
+++ b/src/main/java/foodiepass/server/menu/infra/scraper/gemini/GeminiFoodScrapper.java
@@ -2,6 +2,7 @@ package foodiepass.server.menu.infra.scraper.gemini;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import foodiepass.server.global.config.ProfileConstants;
 import foodiepass.server.menu.application.port.out.FoodScrapper;
 import foodiepass.server.menu.domain.FoodInfo;
 import foodiepass.server.menu.infra.exception.GeminiErrorCode;
@@ -20,7 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Component("geminiFoodScrapper")
 @Primary
-@Profile("!performance-test")
+@Profile(ProfileConstants.NOT_PERFORMANCE_TEST)
 @RequiredArgsConstructor
 public class GeminiFoodScrapper implements FoodScrapper {
 

--- a/src/main/java/foodiepass/server/menu/infra/scraper/gemini/GeminiOcrReader.java
+++ b/src/main/java/foodiepass/server/menu/infra/scraper/gemini/GeminiOcrReader.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
-@Profile("!test")
+@Profile("!test & !performance-test")
 public class GeminiOcrReader implements OcrReader {
 
     public static final String JSON_EXTRACT_PROMPT_MESSAGE = "Given a menu image, please extract and print the names and prices of the food items in JSON format. Follow the structure below for each item:\n\n[{\"name\": \"Name of the Food (String)\", \"price\": Price of the Food (double)}, ...]";

--- a/src/main/java/foodiepass/server/menu/infra/scraper/gemini/GeminiOcrReader.java
+++ b/src/main/java/foodiepass/server/menu/infra/scraper/gemini/GeminiOcrReader.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
+import foodiepass.server.global.config.ProfileConstants;
 import foodiepass.server.menu.application.port.out.OcrReader;
 import foodiepass.server.menu.domain.MenuItem;
 import foodiepass.server.menu.infra.exception.GeminiErrorCode;
@@ -17,7 +18,7 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
-@Profile("!test & !performance-test")
+@Profile(ProfileConstants.NOT_TEST_AND_NOT_PERFORMANCE_TEST)
 public class GeminiOcrReader implements OcrReader {
 
     public static final String JSON_EXTRACT_PROMPT_MESSAGE = "Given a menu image, please extract and print the names and prices of the food items in JSON format. Follow the structure below for each item:\n\n[{\"name\": \"Name of the Food (String)\", \"price\": Price of the Food (double)}, ...]";

--- a/src/main/java/foodiepass/server/menu/infra/scraper/tasteAtlas/TasteAtlasApiClient.java
+++ b/src/main/java/foodiepass/server/menu/infra/scraper/tasteAtlas/TasteAtlasApiClient.java
@@ -7,6 +7,7 @@ import foodiepass.server.menu.infra.exception.ScrapingException;
 import foodiepass.server.menu.infra.scraper.auth.domain.Authenticatable;
 import foodiepass.server.menu.infra.scraper.tasteAtlas.dto.TasteAtlasResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -14,6 +15,7 @@ import reactor.core.publisher.Mono;
 
 @Slf4j
 @Component
+@Profile("!performance-test")
 public class TasteAtlasApiClient implements Authenticatable {
 
     private final WebClient webClient;

--- a/src/main/java/foodiepass/server/menu/infra/scraper/tasteAtlas/TasteAtlasApiClient.java
+++ b/src/main/java/foodiepass/server/menu/infra/scraper/tasteAtlas/TasteAtlasApiClient.java
@@ -1,6 +1,7 @@
 package foodiepass.server.menu.infra.scraper.tasteAtlas;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import foodiepass.server.global.config.ProfileConstants;
 import foodiepass.server.menu.infra.config.TasteAtlasProperties;
 import foodiepass.server.menu.infra.exception.ScrapingErrorCode;
 import foodiepass.server.menu.infra.exception.ScrapingException;
@@ -15,7 +16,7 @@ import reactor.core.publisher.Mono;
 
 @Slf4j
 @Component
-@Profile("!performance-test")
+@Profile(ProfileConstants.NOT_PERFORMANCE_TEST)
 public class TasteAtlasApiClient implements Authenticatable {
 
     private final WebClient webClient;

--- a/src/main/java/foodiepass/server/menu/infra/scraper/tasteAtlas/TasteAtlasFoodScrapper.java
+++ b/src/main/java/foodiepass/server/menu/infra/scraper/tasteAtlas/TasteAtlasFoodScrapper.java
@@ -1,5 +1,6 @@
 package foodiepass.server.menu.infra.scraper.tasteAtlas;
 
+import foodiepass.server.global.config.ProfileConstants;
 import foodiepass.server.menu.application.port.out.FoodScrapper;
 import foodiepass.server.menu.domain.FoodInfo;
 import foodiepass.server.menu.infra.config.TasteAtlasProperties;
@@ -21,7 +22,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
 @Component("tasteAtlasFoodScrapper")
-@Profile("!performance-test")
+@Profile(ProfileConstants.NOT_PERFORMANCE_TEST)
 @RequiredArgsConstructor
 public class TasteAtlasFoodScrapper implements FoodScrapper {
 

--- a/src/main/java/foodiepass/server/menu/infra/scraper/tasteAtlas/TasteAtlasFoodScrapper.java
+++ b/src/main/java/foodiepass/server/menu/infra/scraper/tasteAtlas/TasteAtlasFoodScrapper.java
@@ -6,6 +6,7 @@ import foodiepass.server.menu.infra.config.TasteAtlasProperties;
 import foodiepass.server.menu.infra.scraper.tasteAtlas.dto.TasteAtlasResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 import reactor.core.publisher.Flux;
@@ -20,6 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
 @Component("tasteAtlasFoodScrapper")
+@Profile("!performance-test")
 @RequiredArgsConstructor
 public class TasteAtlasFoodScrapper implements FoodScrapper {
 

--- a/src/main/java/foodiepass/server/menu/infra/scraper/url/UrlFoodScrapper.java
+++ b/src/main/java/foodiepass/server/menu/infra/scraper/url/UrlFoodScrapper.java
@@ -6,6 +6,7 @@ import foodiepass.server.menu.infra.config.TasteAtlasProperties;
 import foodiepass.server.menu.infra.scraper.tasteAtlas.TasteAtlasApiClient;
 import foodiepass.server.menu.infra.scraper.tasteAtlas.TasteAtlasPageParser;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -16,6 +17,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Component
+@Profile("!performance-test")
 @RequiredArgsConstructor
 public class UrlFoodScrapper implements FoodScrapper {
 

--- a/src/main/java/foodiepass/server/menu/infra/scraper/url/UrlFoodScrapper.java
+++ b/src/main/java/foodiepass/server/menu/infra/scraper/url/UrlFoodScrapper.java
@@ -1,5 +1,6 @@
 package foodiepass.server.menu.infra.scraper.url;
 
+import foodiepass.server.global.config.ProfileConstants;
 import foodiepass.server.menu.application.port.out.FoodScrapper;
 import foodiepass.server.menu.domain.FoodInfo;
 import foodiepass.server.menu.infra.config.TasteAtlasProperties;
@@ -17,7 +18,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Component
-@Profile("!performance-test")
+@Profile(ProfileConstants.NOT_PERFORMANCE_TEST)
 @RequiredArgsConstructor
 public class UrlFoodScrapper implements FoodScrapper {
 

--- a/src/main/java/foodiepass/server/script/application/ScriptFactory.java
+++ b/src/main/java/foodiepass/server/script/application/ScriptFactory.java
@@ -32,15 +32,6 @@ public class ScriptFactory {
         prefixCache.put(ENGLISH, ENGLISH_SCRIPT_PREFIX);
     }
 
-    public Script create(final Language sourceLanguage, final Language targetLanguage, final List<OrderItem> orderItems) {
-        final String prefix = getOrTranslatePrefix(sourceLanguage);
-        final String concatenatedOrders = concatOrderItems(orderItems);
-        final String travelerScript = prefix + lineSeparator() + concatenatedOrders;
-        final String localScript = translationClient.translate(sourceLanguage, targetLanguage, travelerScript);
-
-        return new Script(travelerScript, localScript);
-    }
-
     public Mono<Script> createAsync(final Language sourceLanguage, final Language targetLanguage, final List<OrderItem> orderItems) {
         return getOrTranslatePrefixAsync(sourceLanguage)
                 .flatMap(prefix -> {
@@ -52,13 +43,6 @@ public class ScriptFactory {
                 });
     }
 
-    private String getOrTranslatePrefix(final Language language) {
-        return prefixCache.computeIfAbsent(
-                language,
-                lang -> translationClient.translate(ENGLISH, lang, ENGLISH_SCRIPT_PREFIX)
-        );
-    }
-
     private Mono<String> getOrTranslatePrefixAsync(final Language language) {
         if (prefixCache.containsKey(language)) {
             return Mono.just(prefixCache.get(language));
@@ -66,7 +50,6 @@ public class ScriptFactory {
         return translationClient.translateAsync(ENGLISH, language, ENGLISH_SCRIPT_PREFIX)
                 .doOnSuccess(translatedPrefix -> prefixCache.put(language, translatedPrefix));
     }
-
 
     private String concatOrderItems(final List<OrderItem> orderItems) {
         return orderItems.stream()


### PR DESCRIPTION
# 주요 변경사항

- **비동기 처리 도입**: 외부 API(OCR, 번역 등) 호출 로직을 동기 블로킹 방식에서 비동기 논블로킹 방식(Project Reactor)으로 전면 리팩토링했습니다.
- **성능 최적화**: `Mono.zip`을 활용하여 독립적인 I/O 작업(번역, 환율 조회)을 **병렬 처리**하여 전체 응답 시간을 크게 단축했습니다.
- **테스트 환경 구축**: 비용 발생 없이 안정적인 성능 테스트가 가능하도록 **`performance-test` 프로필과 Mock 인프라를 구축**하고, k6 테스트 스크립트를 추가했습니다.
- **아키텍처 개선**: 외부 의존성 인터페이스를 `application/port/out`으로 이동시켜 헥사고날 아키텍처 구조를 일부 적용했습니다.

---

# 성능 개선 결과

동일한 부하 조건(최대 가상 유저 50명)에서 개선 전후 성능을 측정한 결과, 다음과 같이 극적인 성능 향상을 확인했습니다.

| 지표 (Metric) | 개선 전 (Baseline) | 개선 후 (Refactored) | 개선 효과 (Improvement) |
| :--- | :--- | :--- | :--- |
| **성능 목표** | **실패 ❌** | **성공 ✅** | **안정성 확보** |
| **응답 시간 (p95)** | **14.2초** | **6.32ms** | **약 2246배 향상** |
| **평균 응답 시간** | **7.75초** | **3.34ms** | **약 2320배 향상** |
| **초당 요청 처리량** | **4.56개/초** | **39.77개/초**| **약 8.7배 증가** |
| **요청 실패율** | **2.48%** | **0.00%** | **오류 제거** |

<br>

# 🤔 기술적 고민 및 결정

### 1. 다중 I/O 작업의 동시성 처리와 성능 최적화

-   **고민**: 메뉴 아이템 하나를 보강하는 과정은 `1) 메뉴명 번역 → 2) 번역된 이름으로 정보 스크래핑 → 3) 스크래핑된 이름/설명 번역 + 4) 가격 정보 환율 변환` 등 다수의 네트워크 I/O를 필요로 합니다. 이 작업들을 순차적으로 동기 처리할 경우, 각 요청의 지연 시간이 합산되어 사용자 경험을 심각하게 저해할 수 있었습니다.
-   **결정**: Project Reactor(Mono, Flux)를 도입하여 전체 정보 보강 과정을 비동기 파이프라인으로 설계했습니다. 특히 3번과 4번 과정은 서로 의존성이 없으므로, **`Mono.zip`을 사용하여 두 개의 번역 API 호출과 환율 변환 API 호출을 병렬로 동시에 처리**하도록 구현했습니다. 이를 통해 독립적인 I/O 작업들이 서로를 기다리지 않게 되어 전체 응답 시간을 크게 단축하고 성능을 최적화했습니다.

### 2. 블로킹(Blocking) 컨트롤러와 논블로킹(Non-blocking) 서비스의 연결점

-   **고민**: `MenuItemEnricher`의 핵심 로직은 `Mono`를 반환하는 완전한 논블로킹 코드이지만, `MenuController`는 전통적인 Spring MVC(Servlet) 기반의 블로킹 방식으로 동작합니다. 논블로킹 서비스의 결과를 블로킹 컨트롤러에서 어떻게 처리해야 할지 결정이 필요했습니다.
-   **결정**: 현재 구현 단계에서는 컨트롤러-서비스 경계의 복잡성을 최소화하기 위해, `MenuService`에서 `parallelStream()`을 사용하되 최종적으로 **`.block()`을 호출하여 비동기 작업의 결과를 동기적으로 기다리는 방식을 채택**했습니다. 하지만 이 지점이 웹 서버의 스레드를 점유하는 잠재적인 성능 병목 지점임을 인지하고 있습니다. 향후 트래픽 증가 시, **WebFlux를 도입하여 컨트롤러까지 완전한 End-to-End 논블로킹 파이프라인으로 전환하는 리팩토링을 고려**하고자 합니다.

---

## ✅ 참고 사항

- 이 PR이 머지된 후에는 `performance-test` 프로필을 활성화하여 언제든지 서버의 핵심 로직 성능을 측정할 수 있습니다.
  ```bash
  # 1. 빌드
  ./gradlew build

  # 2. performance-test 프로필로 실행
  java -jar -Dspring.profiles.active=performance-test build/libs/server-0.0.1-SNAPSHOT.jar