### PR TITLE
feat: 환율 캐싱 도입을 통한 API 성능 최적화

### DIFF
--- a/currency-api-performance-test.js
+++ b/currency-api-performance-test.js
@@ -1,0 +1,40 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+    vus: 10,
+    duration: '30s',
+
+    thresholds: {
+        'http_req_duration': ['p(95)<200'],
+    },
+};
+
+const API_BASE_URL = 'http://localhost:8080';
+
+export default function () {
+    const url = `${API_BASE_URL}/currency/calculate`;
+
+    const payload = JSON.stringify({
+        originCurrency: "South Korean won",
+        userCurrency: "Japanese Yen",
+        orders: [
+            { originPrice: 10000, quantity: 2 },
+            { originPrice: 5000, quantity: 5 },
+        ],
+    });
+
+    const params = {
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    };
+
+    const res = http.post(url, payload, params);
+
+    check(res, {
+        'status is 200': (r) => r.status === 200,
+    });
+
+    sleep(1);
+}

--- a/src/main/java/foodiepass/server/ServerApplication.java
+++ b/src/main/java/foodiepass/server/ServerApplication.java
@@ -4,8 +4,10 @@ import foodiepass.server.menu.infra.config.TasteAtlasProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 @EnableConfigurationProperties(TasteAtlasProperties.class)
 public class ServerApplication {
 

--- a/src/main/java/foodiepass/server/currency/application/ExchangeRateCache.java
+++ b/src/main/java/foodiepass/server/currency/application/ExchangeRateCache.java
@@ -1,0 +1,24 @@
+package foodiepass.server.currency.application;
+
+import org.springframework.stereotype.Component;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class ExchangeRateCache {
+    private final Map<String, Double> exchangeRateCache = new ConcurrentHashMap<>();
+
+    public Optional<Double> getExchangeRate(String fromCurrencyCode, String toCurrencyCode) {
+        if (fromCurrencyCode.equals(toCurrencyCode)) {
+            return Optional.of(1.0);
+        }
+        String key = fromCurrencyCode + "-" + toCurrencyCode;
+        return Optional.ofNullable(exchangeRateCache.get(key));
+    }
+
+    public void updateExchangeRate(String fromCurrencyCode, String toCurrencyCode, double rate) {
+        String key = fromCurrencyCode + "-" + toCurrencyCode;
+        exchangeRateCache.put(key, rate);
+    }
+}

--- a/src/main/java/foodiepass/server/currency/application/ExchangeRateCache.java
+++ b/src/main/java/foodiepass/server/currency/application/ExchangeRateCache.java
@@ -13,12 +13,16 @@ public class ExchangeRateCache {
         if (fromCurrencyCode.equals(toCurrencyCode)) {
             return Optional.of(1.0);
         }
-        String key = fromCurrencyCode + "-" + toCurrencyCode;
+        String key = generateKey(fromCurrencyCode, toCurrencyCode);
         return Optional.ofNullable(exchangeRateCache.get(key));
     }
 
     public void updateExchangeRate(String fromCurrencyCode, String toCurrencyCode, double rate) {
-        String key = fromCurrencyCode + "-" + toCurrencyCode;
+        String key = generateKey(fromCurrencyCode, toCurrencyCode);
         exchangeRateCache.put(key, rate);
+    }
+
+    private String generateKey(String fromCurrencyCode, String toCurrencyCode) {
+        return fromCurrencyCode + "-" + toCurrencyCode;
     }
 }

--- a/src/main/java/foodiepass/server/currency/application/ExchangeRateScheduler.java
+++ b/src/main/java/foodiepass/server/currency/application/ExchangeRateScheduler.java
@@ -1,0 +1,69 @@
+package foodiepass.server.currency.application;
+
+import foodiepass.server.currency.domain.Currency;
+import foodiepass.server.menu.application.port.out.ExchangeRateProvider;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import reactor.util.function.Tuples;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ExchangeRateScheduler {
+
+    private final ExchangeRateProvider exchangeRateProvider;
+    private final ExchangeRateCache exchangeRateCache;
+
+    @PostConstruct
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    public void updateAllExchangeRates() {
+        log.info("환율 정보 캐시 갱신 작업을 시작합니다...");
+
+        final Currency baseCurrency = Currency.UNITED_STATES_DOLLAR;
+
+        Mono.just(Currency.values())
+                .flatMapMany(currencies -> reactor.core.publisher.Flux.fromArray(currencies)
+                        .filter(currency -> !currency.equals(baseCurrency))
+                        .flatMap(targetCurrency ->
+                                exchangeRateProvider.getExchangeRateAsync(baseCurrency, targetCurrency)
+                                        .map(rate -> Tuples.of(targetCurrency.getCurrencyCode(), rate))
+                                        .onErrorResume(error -> {
+                                            log.error("환율 정보를 가져오는 중 오류 발생: {} -> {}", baseCurrency.getCurrencyCode(), targetCurrency.getCurrencyCode(), error);
+                                            return Mono.empty();
+                                        })
+                        )
+                )
+                .collectMap(tuple -> tuple.getT1(), tuple -> tuple.getT2())
+                .doOnSuccess(ratesMap -> {
+                    if (ratesMap.isEmpty()) {
+                        log.warn("갱신할 환율 정보를 가져오지 못했습니다.");
+                        return;
+                    }
+
+                    ratesMap.forEach((targetCode, rate) -> {
+                        exchangeRateCache.updateExchangeRate(baseCurrency.getCurrencyCode(), targetCode, rate);
+                        exchangeRateCache.updateExchangeRate(targetCode, baseCurrency.getCurrencyCode(), 1.0 / rate);
+                    });
+
+                    for (Map.Entry<String, Double> fromEntry : ratesMap.entrySet()) {
+                        for (Map.Entry<String, Double> toEntry : ratesMap.entrySet()) {
+                            if (fromEntry.getKey().equals(toEntry.getKey())) {
+                                continue;
+                            }
+
+                            double crossRate = toEntry.getValue() / fromEntry.getValue();
+                            exchangeRateCache.updateExchangeRate(fromEntry.getKey(), toEntry.getKey(), crossRate);
+                        }
+                    }
+
+                    log.info("총 {}개의 통화에 대한 환율 캐시 갱신을 완료했습니다.", ratesMap.size());
+                })
+                .subscribe();
+    }
+}

--- a/src/main/java/foodiepass/server/currency/application/ExchangeRateScheduler.java
+++ b/src/main/java/foodiepass/server/currency/application/ExchangeRateScheduler.java
@@ -21,8 +21,16 @@ public class ExchangeRateScheduler {
     private final ExchangeRateCache exchangeRateCache;
 
     @PostConstruct
+    public void initializeCacheOnStartup() {
+        updateAllExchangeRatesInternal();
+    }
+
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
-    public void updateAllExchangeRates() {
+    public void scheduledCacheUpdate() {
+        updateAllExchangeRatesInternal();
+    }
+
+    private void updateAllExchangeRatesInternal() {
         log.info("환율 정보 캐시 갱신 작업을 시작합니다...");
 
         final Currency baseCurrency = Currency.UNITED_STATES_DOLLAR;
@@ -64,6 +72,9 @@ public class ExchangeRateScheduler {
 
                     log.info("총 {}개의 통화에 대한 환율 캐시 갱신을 완료했습니다.", ratesMap.size());
                 })
-                .subscribe();
+                .subscribe(
+                        null,
+                        error -> log.error("환율 정보 캐시 갱신 스트림에 치명적인 오류가 발생했습니다.", error)
+                );
     }
 }

--- a/src/main/java/foodiepass/server/currency/exception/CurrencyErrorCode.java
+++ b/src/main/java/foodiepass/server/currency/exception/CurrencyErrorCode.java
@@ -11,7 +11,10 @@ public enum CurrencyErrorCode implements ErrorCode {
 
     CURRENCY_NOT_FOUND(HttpStatus.NOT_FOUND, "유효하지 않은 통화입니다."),
     INVALID_CURRENCY_INPUT(HttpStatus.BAD_REQUEST, "통화 이름 또는 코드는 비어있을 수 없습니다."),
-    UNSUPPORTED_CURRENCY_CODE(HttpStatus.INTERNAL_SERVER_ERROR, "자바 라이브러리에서 지원하지 않는 통화 코드입니다.");
+    UNSUPPORTED_CURRENCY_CODE(HttpStatus.INTERNAL_SERVER_ERROR, "자바 라이브러리에서 지원하지 않는 통화 코드입니다."),
+
+    EXCHANGE_RATE_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "환율 정보를 찾을 수 없습니다."),
+    ;
 
     private final HttpStatus status;
     private final String message;

--- a/src/test/java/foodiepass/server/currency/application/CurrencyServiceTest.java
+++ b/src/test/java/foodiepass/server/currency/application/CurrencyServiceTest.java
@@ -1,13 +1,9 @@
 package foodiepass.server.currency.application;
 
-import foodiepass.server.common.price.domain.Price;
 import foodiepass.server.currency.domain.Currency;
 import foodiepass.server.currency.dto.request.CalculatePriceRequest;
 import foodiepass.server.currency.dto.response.CalculatePriceResponse;
-import foodiepass.server.currency.dto.response.CurrencyResponse;
 import foodiepass.server.currency.exception.CurrencyException;
-import foodiepass.server.menu.application.port.out.ExchangeRateProvider;
-import foodiepass.server.menu.dto.response.ReconfigureResponse.PriceInfoResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -20,11 +16,8 @@ import reactor.test.StepVerifier;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Optional;
 
-import static foodiepass.server.currency.exception.CurrencyErrorCode.CURRENCY_NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -35,113 +28,61 @@ class CurrencyServiceTest {
     private CurrencyService currencyService;
 
     @Mock
-    private ExchangeRateProvider exchangeRateProvider;
-
-    @Test
-    @DisplayName("findAllCurrencies 호출 시 모든 통화 목록을 반환한다")
-    void findAllCurrencies_shouldReturnAllCurrencies() {
-        // given
-        int expectedSize = Currency.values().length;
-
-        // when
-        List<CurrencyResponse> responses = currencyService.findAllCurrencies();
-
-        // then
-        assertThat(responses).isNotNull();
-        assertThat(responses.size()).isEqualTo(expectedSize);
-        assertThat(responses)
-                .extracting(CurrencyResponse::currencyName)
-                .contains(Currency.SOUTH_KOREAN_WON.getCurrencyName());
-    }
-
-    @Test
-    @DisplayName("convertAndFormatAsync는 가격을 비동기적으로 변환하고 포맷팅한다")
-    void convertAndFormatAsync_shouldConvertAndFormatPrice() {
-        // given
-        Price originPrice = new Price(Currency.SOUTH_KOREAN_WON, new BigDecimal("1000"));
-        Currency userCurrency = Currency.JAPANESE_YEN;
-        double exchangeRate = 10.5;
-
-        given(exchangeRateProvider.getExchangeRateAsync(Currency.SOUTH_KOREAN_WON, userCurrency))
-                .willReturn(Mono.just(exchangeRate));
-
-        // when
-        Mono<PriceInfoResponse> result = currencyService.convertAndFormatAsync(originPrice, userCurrency);
-
-        // then
-        StepVerifier.create(result)
-                .expectNextMatches(priceInfo ->
-                        priceInfo.originPriceWithCurrencyUnit().contains("₩") &&
-                                priceInfo.userPriceWithCurrencyUnit().contains("¥")
-                )
-                .verifyComplete();
-    }
+    private ExchangeRateCache exchangeRateCache;
 
     @Nested
-    @DisplayName("calculateOrdersPrice 메소드는")
-    class Describe_calculateOrdersPrice {
+    @DisplayName("calculateOrdersPriceAsync 메소드는")
+    class Describe_calculateOrdersPriceAsync {
 
         @Test
-        @DisplayName("정상적인 요청에 대해 올바른 가격을 계산하여 반환한다")
-        void withValidRequest_shouldCalculateAndReturnCorrectPrice() {
+        @DisplayName("캐시에 환율 정보가 있으면 올바른 가격을 계산하여 반환한다")
+        void withRateInCache_shouldCalculateAndReturnCorrectPrice() {
             // given
             List<CalculatePriceRequest.OrderElementRequest> orders = List.of(
-                    new CalculatePriceRequest.OrderElementRequest(new BigDecimal("15.99"), new BigDecimal("1")),
-                    new CalculatePriceRequest.OrderElementRequest(new BigDecimal("4.50"), new BigDecimal("2"))
+                    new CalculatePriceRequest.OrderElementRequest(new BigDecimal("10.00"), new BigDecimal("2"))
             );
-
             CalculatePriceRequest request = new CalculatePriceRequest("United States Dollar", "South Korean won", orders);
 
-            given(exchangeRateProvider.getExchangeRate(Currency.UNITED_STATES_DOLLAR, Currency.SOUTH_KOREAN_WON))
-                    .willReturn(1350.50);
+            String from = Currency.UNITED_STATES_DOLLAR.getCurrencyCode();
+            String to = Currency.SOUTH_KOREAN_WON.getCurrencyCode();
+            double exchangeRate = 1350.50;
+
+            given(exchangeRateCache.getExchangeRate(from, to)).willReturn(Optional.of(exchangeRate));
 
             // when
-            CalculatePriceResponse response = currencyService.calculateOrdersPrice(request);
+            Mono<CalculatePriceResponse> result = currencyService.calculateOrdersPriceAsync(request);
 
             // then
-            assertThat(response).isNotNull();
-            assertThat(response.originTotalPrice().value()).isEqualByComparingTo("24.99");
-            assertThat(response.originTotalPrice().currencyCode()).isEqualTo("USD");
-            assertThat(response.userTotalPrice().value()).isEqualByComparingTo("33749.00");
-            assertThat(response.userTotalPrice().currencyCode()).isEqualTo("KRW");
+            StepVerifier.create(result)
+                    .expectNextMatches(response -> {
+                        boolean priceMatches = response.userTotalPrice().value().compareTo(new BigDecimal("27010.00")) == 0;
+                        boolean currencyMatches = response.userTotalPrice().currencyCode().equals("KRW");
+                        return priceMatches && currencyMatches;
+                    })
+                    .verifyComplete();
         }
 
         @Test
-        @DisplayName("유효하지 않은 통화 이름이 포함된 경우 CurrencyException을 던진다")
-        void withInvalidCurrencyName_shouldThrowCurrencyException() {
+        @DisplayName("캐시에 환율 정보가 없으면 CurrencyException을 발생시킨다")
+        void withNoRateInCache_shouldThrowCurrencyException() {
             // given
             List<CalculatePriceRequest.OrderElementRequest> orders = List.of(
                     new CalculatePriceRequest.OrderElementRequest(new BigDecimal("10.00"), new BigDecimal("1"))
             );
-            CalculatePriceRequest request = new CalculatePriceRequest("United States Dollar", "Invalid Currency", orders);
+            CalculatePriceRequest request = new CalculatePriceRequest("United States Dollar", "Japanese Yen", orders);
 
-            // when & then
-            assertThatThrownBy(() -> currencyService.calculateOrdersPrice(request))
-                    .isInstanceOf(CurrencyException.class)
-                    .hasMessage(CURRENCY_NOT_FOUND.getMessage());
-        }
+            String from = Currency.UNITED_STATES_DOLLAR.getCurrencyCode();
+            String to = Currency.JAPANESE_YEN.getCurrencyCode();
 
-        @Test
-        @DisplayName("원본 통화와 사용자 통화가 같을 경우 환율 1.0을 적용한다")
-        void withSameOriginAndUserCurrency_shouldApplyExchangeRateOfOne() {
-            // given
-            List<CalculatePriceRequest.OrderElementRequest> orders = List.of(
-                    new CalculatePriceRequest.OrderElementRequest(new BigDecimal("100.00"), new BigDecimal("1"))
-            );
-            CalculatePriceRequest request = new CalculatePriceRequest("South Korean won", "South Korean won", orders);
-
-            given(exchangeRateProvider.getExchangeRate(any(Currency.class), any(Currency.class)))
-                    .willReturn(1.0);
+            given(exchangeRateCache.getExchangeRate(from, to)).willReturn(Optional.empty());
 
             // when
-            CalculatePriceResponse response = currencyService.calculateOrdersPrice(request);
+            Mono<CalculatePriceResponse> result = currencyService.calculateOrdersPriceAsync(request);
 
             // then
-            assertThat(response).isNotNull();
-            assertThat(response.originTotalPrice().value()).isEqualByComparingTo("100.00");
-            assertThat(response.userTotalPrice().value()).isEqualByComparingTo("100.00");
-            assertThat(response.originTotalPrice().currencyCode()).isEqualTo("KRW");
-            assertThat(response.userTotalPrice().currencyCode()).isEqualTo("KRW");
+            StepVerifier.create(result)
+                    .expectError(CurrencyException.class)
+                    .verify();
         }
     }
 }

--- a/src/test/java/foodiepass/server/currency/application/ExchangeRateCacheTest.java
+++ b/src/test/java/foodiepass/server/currency/application/ExchangeRateCacheTest.java
@@ -1,0 +1,56 @@
+package foodiepass.server.currency.application;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ExchangeRateCache 테스트")
+class ExchangeRateCacheTest {
+
+    private ExchangeRateCache exchangeRateCache;
+
+    @BeforeEach
+    void setUp() {
+        exchangeRateCache = new ExchangeRateCache();
+    }
+
+    @Test
+    @DisplayName("환율 정보를 저장하고 올바르게 조회한다")
+    void shouldStoreAndRetrieveRateCorrectly() {
+        // given
+        String from = "USD";
+        String to = "KRW";
+        double rate = 1300.0;
+        exchangeRateCache.updateExchangeRate(from, to, rate);
+
+        // when
+        Optional<Double> retrievedRate = exchangeRateCache.getExchangeRate(from, to);
+
+        // then
+        assertThat(retrievedRate).isPresent().contains(rate);
+    }
+
+    @Test
+    @DisplayName("동일 통화 조회 시 환율 1.0을 반환한다")
+    void whenSameCurrency_shouldReturnRateOfOne() {
+        // when
+        Optional<Double> retrievedRate = exchangeRateCache.getExchangeRate("USD", "USD");
+
+        // then
+        assertThat(retrievedRate).isPresent().contains(1.0);
+    }
+
+    @Test
+    @DisplayName("캐시에 없는 환율 조회 시 Optional.empty를 반환한다")
+    void whenRateNotExists_shouldReturnEmptyOptional() {
+        // when
+        Optional<Double> retrievedRate = exchangeRateCache.getExchangeRate("EUR", "GBP");
+
+        // then
+        assertThat(retrievedRate).isEmpty();
+    }
+}

--- a/src/test/java/foodiepass/server/currency/application/ExchangeRateSchedulerTest.java
+++ b/src/test/java/foodiepass/server/currency/application/ExchangeRateSchedulerTest.java
@@ -30,12 +30,11 @@ class ExchangeRateSchedulerTest {
     private ExchangeRateCache exchangeRateCache;
 
     @Test
-    @DisplayName("updateAllExchangeRates 호출 시 환율을 가져와 캐시를 올바르게 업데이트한다")
-    void shouldUpdateCacheWithFetchedRates() {
+    @DisplayName("초기화 메소드 호출 시 환율을 가져와 캐시를 올바르게 업데이트한다")
+    void initializeCacheOnStartup_shouldFetchRatesAndCorrectlyUpdateCache() {
         // given
         given(exchangeRateProvider.getExchangeRateAsync(any(Currency.class), any(Currency.class)))
                 .willAnswer(invocation -> {
-                    Currency base = invocation.getArgument(0);
                     Currency target = invocation.getArgument(1);
 
                     if (target.equals(Currency.SOUTH_KOREAN_WON)) {
@@ -48,7 +47,7 @@ class ExchangeRateSchedulerTest {
                 });
 
         // when
-        exchangeRateScheduler.updateAllExchangeRates();
+        exchangeRateScheduler.initializeCacheOnStartup();
 
         // then
         ArgumentCaptor<String> fromCaptor = ArgumentCaptor.forClass(String.class);

--- a/src/test/java/foodiepass/server/currency/application/ExchangeRateSchedulerTest.java
+++ b/src/test/java/foodiepass/server/currency/application/ExchangeRateSchedulerTest.java
@@ -1,0 +1,64 @@
+package foodiepass.server.currency.application;
+
+import foodiepass.server.currency.domain.Currency;
+import foodiepass.server.menu.application.port.out.ExchangeRateProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ExchangeRateScheduler 테스트")
+class ExchangeRateSchedulerTest {
+
+    @InjectMocks
+    private ExchangeRateScheduler exchangeRateScheduler;
+
+    @Mock
+    private ExchangeRateProvider exchangeRateProvider;
+
+    @Mock
+    private ExchangeRateCache exchangeRateCache;
+
+    @Test
+    @DisplayName("updateAllExchangeRates 호출 시 환율을 가져와 캐시를 올바르게 업데이트한다")
+    void shouldUpdateCacheWithFetchedRates() {
+        // given
+        given(exchangeRateProvider.getExchangeRateAsync(any(Currency.class), any(Currency.class)))
+                .willAnswer(invocation -> {
+                    Currency base = invocation.getArgument(0);
+                    Currency target = invocation.getArgument(1);
+
+                    if (target.equals(Currency.SOUTH_KOREAN_WON)) {
+                        return Mono.just(1350.0);
+                    }
+                    if (target.equals(Currency.JAPANESE_YEN)) {
+                        return Mono.just(150.0);
+                    }
+                    return Mono.just(1.0);
+                });
+
+        // when
+        exchangeRateScheduler.updateAllExchangeRates();
+
+        // then
+        ArgumentCaptor<String> fromCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> toCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Double> rateCaptor = ArgumentCaptor.forClass(Double.class);
+
+        verify(exchangeRateCache, atLeastOnce()).updateExchangeRate(fromCaptor.capture(), toCaptor.capture(), rateCaptor.capture());
+
+        verify(exchangeRateCache).updateExchangeRate("USD", "KRW", 1350.0);
+        verify(exchangeRateCache).updateExchangeRate("KRW", "USD", 1.0 / 1350.0);
+        verify(exchangeRateCache).updateExchangeRate("KRW", "JPY", 150.0 / 1350.0);
+    }
+}


### PR DESCRIPTION
# 📄 Work Description

기존에 환율 계산 요청 시마다 외부 API를 호출하던 로직을 개선하여, 서버 성능을 향상시키고 외부 의존성을 낮췄습니다.

-   **환율 캐싱 시스템 도입**:
    -   `ExchangeRateCache`: 환율 정보를 서버 메모리에 저장하는 캐시 컴포넌트를 추가했습니다.
    -   `ExchangeRateScheduler`: `@Scheduled`를 이용해 주기적으로(매일 자정) 외부 API에서 환율 정보를 비동기적으로 가져와 캐시를 갱신합니다. 서버 시작 시에도 `@PostConstruct`를 통해 즉시 캐시를 채우도록 했습니다.
-   **`CurrencyService` 리팩토링**:
    -   `ExchangeRateProvider`에 대한 직접 의존성을 제거하고, `ExchangeRateCache`를 조회하도록 로직을 변경하여 API 응답 시간을 크게 단축했습니다.
-   **성능 테스트 환경 구축**:
    -   개선 효과를 객관적으로 측정하고, 향후 성능 저하를 방지하기 위해 k6 부하 테스트 스크립트를 추가했습니다.

---

# 성능 개선 결과 

k6를 이용한 동일 부하 조건(가상 유저 10명, 30초)에서 개선 전후 성능을 측정한 결과, 다음과 같이 극적인 성능 향상을 확인했습니다.

| 지표 (Metric) | 개선 전 (AS-IS) | **개선 후 (TO-BE)** | 개선 효과 (Improvement) |
| :--- | :--- | :--- | :--- |
| **성능 목표 (`p(95)<200ms`)** | **실패 ❌** | **성공 ✅** | **안정성 확보** |
| **응답 시간 (`p(95)`)** | 977.1 ms | **32.81 ms** | **약 96.6% 감소 (30배 향상)** |
| **평균 응답 시간** | 645.27 ms | **14.6 ms** | **약 97.7% 감소 (44배 향상)** |
| **초당 요청 처리량 (RPS)** | 5.93 /s | **9.82 /s** | **약 65% 증가**¹ |

¹ 처리량(RPS)은 서버의 한계가 아닌, 테스트 스크립트의 `sleep(1)` 설정으로 인해 제한되었습니다. 실제 서버는 훨씬 더 높은 트래픽을 처리할 수 있습니다.

---

# 🤔 고민한 내용

#### 1. Polling 방식 채택: On-demand 방식의 한계 극복
-   **고민**: 기존 On-demand 방식은 사용자 요청이 있을 때마다 외부 API를 호출하여 ① 높은 응답 지연, ② 외부 API 장애 시 서비스 직접 영향, ③ 불필요한 API 호출 비용이라는 명확한 한계가 있었습니다.
-   **결정**: 백그라운드에서 주기적으로 환율 정보를 미리 가져와 캐시에 저장하는 **폴링(Polling) 방식**을 채택했습니다.
-   **근거**: 환율 정보는 실시간성이 아닌 일관성이 더 중요하며, 하루에 한 번 업데이트로 충분한 데이터입니다. 이 아키텍처는 사용자 요청의 응답 시간을 외부 API 상태와 완전히 분리하여, 항상 빠르고 안정적인 서비스 경험을 제공하도록 만들었습니다.

#### 2. 인메모리 캐시 vs. 분산 캐시
-   **고민**: 캐시 저장소로 `ConcurrentHashMap` 기반의 인메모리 캐시와 Redis 같은 분산 캐시를 두고 고민했습니다.
-   **결정**: 현재 아키텍처에서는 **인메모리 캐시**가 가장 합리적이라고 판단했습니다.
-   **근거**: 현재 서비스는 단일 인스턴스로 운영되므로, 외부 인프라 의존성 없이 가장 간단하고 빠르게 구현할 수 있는 인메모리 방식이 효율적이라고 생각했습니다. 향후 서비스가 여러 인스턴스로 확장될 경우, 모든 인스턴스가 동일한 데이터를 참조할 수 있도록 **Redis 도입을 다음 단계로 고려**할 수 있을 것 같습니다