### PR TITLE
feat: Resilience4j 서킷 브레이커 도입을 통한 시스템 안정성 향상

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
+
+	// Resilience4j
+	implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
 
 	// Google Cloud & OCR
 	implementation 'com.google.cloud:google-cloud-vertexai'
@@ -49,6 +53,7 @@ dependencies {
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.projectreactor:reactor-test'
+	testImplementation 'org.wiremock:wiremock-standalone:3.9.1'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	runtimeOnly 'com.h2database:h2'
 }

--- a/src/main/java/foodiepass/server/menu/infra/exception/GeminiErrorCode.java
+++ b/src/main/java/foodiepass/server/menu/infra/exception/GeminiErrorCode.java
@@ -15,8 +15,7 @@ public enum GeminiErrorCode implements ErrorCode {
 
     FOOD_INFO_SCRAP_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "음식 정보 스크래핑 중 오류가 발생했습니다."),
 
-    EXTERNAL_API_CIRCUIT_OPEN(HttpStatus.SERVICE_UNAVAILABLE, "외부 API 서킷이 열려 요청을 처리할 수 없습니다."),
-    ;
+    EXTERNAL_API_CIRCUIT_OPEN(HttpStatus.SERVICE_UNAVAILABLE, "외부 API 서킷이 열려 요청을 처리할 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/foodiepass/server/menu/infra/exception/GeminiErrorCode.java
+++ b/src/main/java/foodiepass/server/menu/infra/exception/GeminiErrorCode.java
@@ -13,8 +13,9 @@ public enum GeminiErrorCode implements ErrorCode {
 
     OCR_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Gemini OCR 요청 처리 중 오류가 발생했습니다."),
 
-    FOOD_INFO_SCRAP_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "음식 정보 스크래핑 중 오류가 발생했습니다.");
+    FOOD_INFO_SCRAP_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "음식 정보 스크래핑 중 오류가 발생했습니다."),
 
+    EXTERNAL_API_CIRCUIT_OPEN(HttpStatus.SERVICE_UNAVAILABLE, "외부 API 서킷이 열려 요청을 처리할 수 없습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/foodiepass/server/menu/infra/exception/ScrapingErrorCode.java
+++ b/src/main/java/foodiepass/server/menu/infra/exception/ScrapingErrorCode.java
@@ -17,8 +17,7 @@ public enum ScrapingErrorCode implements ErrorCode {
     TASTE_ATLAS_HTML_FETCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "TasteAtlas HTML 페이지를 가져오는 데 실패했습니다."),
     TASTE_ATLAS_NO_RESULT(HttpStatus.NOT_FOUND, "TasteAtlas 검색 결과가 없습니다."),
 
-    EXTERNAL_API_CIRCUIT_OPEN(HttpStatus.SERVICE_UNAVAILABLE, "외부 API 서킷이 열려 요청을 처리할 수 없습니다."),
-    ;
+    EXTERNAL_API_CIRCUIT_OPEN(HttpStatus.SERVICE_UNAVAILABLE, "외부 API 서킷이 열려 요청을 처리할 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/foodiepass/server/menu/infra/exception/ScrapingErrorCode.java
+++ b/src/main/java/foodiepass/server/menu/infra/exception/ScrapingErrorCode.java
@@ -15,7 +15,10 @@ public enum ScrapingErrorCode implements ErrorCode {
     TASTE_ATLAS_API_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "TasteAtlas API 요청에 실패했습니다."),
     TASTE_ATLAS_JSON_PARSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "TasteAtlas API 응답 파싱에 실패했습니다."),
     TASTE_ATLAS_HTML_FETCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "TasteAtlas HTML 페이지를 가져오는 데 실패했습니다."),
-    TASTE_ATLAS_NO_RESULT(HttpStatus.NOT_FOUND, "TasteAtlas 검색 결과가 없습니다.");
+    TASTE_ATLAS_NO_RESULT(HttpStatus.NOT_FOUND, "TasteAtlas 검색 결과가 없습니다."),
+
+    EXTERNAL_API_CIRCUIT_OPEN(HttpStatus.SERVICE_UNAVAILABLE, "외부 API 서킷이 열려 요청을 처리할 수 없습니다."),
+    ;
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/foodiepass/server/menu/infra/scraper/tasteAtlas/TasteAtlasApiClient.java
+++ b/src/main/java/foodiepass/server/menu/infra/scraper/tasteAtlas/TasteAtlasApiClient.java
@@ -7,7 +7,7 @@ import foodiepass.server.menu.infra.exception.ScrapingErrorCode;
 import foodiepass.server.menu.infra.exception.ScrapingException;
 import foodiepass.server.menu.infra.scraper.auth.domain.Authenticatable;
 import foodiepass.server.menu.infra.scraper.tasteAtlas.dto.TasteAtlasResponse;
-import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker; 
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
@@ -70,11 +70,11 @@ public class TasteAtlasApiClient implements Authenticatable {
 
     public Mono<TasteAtlasResponse> fallbackSearch(String foodName, Throwable t) {
         log.warn("Circuit Breaker is open for TasteAtlas search. foodName: {}. error: {}", foodName, t.getMessage());
-        return Mono.empty();
+        return Mono.error(new ScrapingException(ScrapingErrorCode.EXTERNAL_API_CIRCUIT_OPEN));
     }
 
     public Mono<String> fallbackFetchHtml(final String url, Throwable t) {
         log.warn("Circuit Breaker is open for TasteAtlas fetchHtml. url: {}. error: {}", url, t.getMessage());
-        return Mono.empty();
+        return Mono.error(new ScrapingException(ScrapingErrorCode.EXTERNAL_API_CIRCUIT_OPEN));
     }
 }

--- a/src/test/java/foodiepass/server/currency/infra/GoogleFinanceRateProviderCircuitBreakerTest.java
+++ b/src/test/java/foodiepass/server/currency/infra/GoogleFinanceRateProviderCircuitBreakerTest.java
@@ -1,0 +1,81 @@
+package foodiepass.server.currency.infra;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import foodiepass.server.currency.domain.Currency;
+import foodiepass.server.menu.application.port.out.ExchangeRateProvider;
+import foodiepass.server.menu.application.port.out.OcrReader;
+import foodiepass.server.menu.infra.exception.ScrapingErrorCode;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class GoogleFinanceRateProviderCircuitBreakerTest {
+
+    @Autowired
+    private ExchangeRateProvider exchangeRateProvider;
+
+    @MockitoBean
+    private OcrReader ocrReader;
+
+    static WireMockServer wireMockServer;
+
+    @BeforeAll
+    static void startMockServer() {
+        wireMockServer = new WireMockServer(0);
+        wireMockServer.start();
+    }
+
+    @AfterAll
+    static void stopMockServer() {
+        wireMockServer.stop();
+    }
+
+    @BeforeEach
+    void setup() {
+        WireMock.configureFor("localhost", wireMockServer.port());
+    }
+
+    @DynamicPropertySource
+    static void overrideProperties(DynamicPropertyRegistry registry) {
+        registry.add("jsoup.google-finance.url-format", () -> wireMockServer.baseUrl() + "/finance/quote/%s-%s");
+    }
+
+    @Test
+    @DisplayName("ExchangeRateProvider 호출이 반복 실패하면 서킷 브레이커가 열린다")
+    void circuitBreaker_shouldOpen_onRepeatedFailures() {
+        // given
+        stubFor(get(urlPathMatching("/finance/quote/USD-JPY"))
+                .willReturn(aResponse().withStatus(503)));
+
+        // when & then
+        for (int i = 0; i < 10; i++) {
+            assertThatThrownBy(() -> {
+                exchangeRateProvider.getExchangeRate(Currency.UNITED_STATES_DOLLAR, Currency.JAPANESE_YEN);
+            }).isInstanceOf(foodiepass.server.menu.infra.exception.ScrapingException.class);
+        }
+
+        assertThatThrownBy(() -> {
+            exchangeRateProvider.getExchangeRate(Currency.UNITED_STATES_DOLLAR, Currency.JAPANESE_YEN);
+        })
+                .isInstanceOf(foodiepass.server.menu.infra.exception.ScrapingException.class)
+                .extracting("errorCode")
+                .isEqualTo(ScrapingErrorCode.EXTERNAL_API_CIRCUIT_OPEN);
+    }
+}

--- a/src/test/java/foodiepass/server/currency/infra/MockApiServer.java
+++ b/src/test/java/foodiepass/server/currency/infra/MockApiServer.java
@@ -1,0 +1,21 @@
+package foodiepass.server.currency.infra;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+public class MockApiServer {
+
+    public static void main(String[] args) throws InterruptedException {
+        WireMockServer wireMockServer = new WireMockServer(0);
+        wireMockServer.start();
+        System.out.println("Mock API Server is running on port: " + wireMockServer.port());
+
+        stubFor(get(urlPathMatching("/finance/quote/.*"))
+                .willReturn(aResponse()
+                        .withStatus(503)
+                        .withFixedDelay(10000)
+                ));
+
+        Thread.currentThread().join();
+    }
+}


### PR DESCRIPTION
# 📄 Work Description

외부 API(환율, 번역, OCR 등)의 일시적인 장애나 성능 저하가 전체 시스템의 장애로 확산되는 것을 방지하기 위해, **Resilience4j 라이브러리를 이용한 서킷 브레이커(Circuit Breaker) 패턴을 도입**했습니다.

-   **서킷 브레이커 적용**:
    -   외부 네트워크 호출이 발생하는 모든 클라이언트(`GoogleFinanceRateProvider`, `TasteAtlasApiClient`, `GeminiClient`)의 공개 메소드에 `@CircuitBreaker` 어노테이션을 적용했습니다.
    -   각 API의 특성에 맞춰 실패율, 최소 호출 횟수, 차단 시간 등 동작 규칙을 `application.yml`에 상세히 설정했습니다.
-   **Fallback 로직 구현**:
    -   서킷이 차단(OPEN)되었을 때 즉시 실행될 `fallbackMethod`를 구현했습니다.
    -   Fallback 로직은 장애 상황을 로그로 남기고, 시스템의 다른 부분에 장애 사실을 명확히 전파하기 위해 `EXTERNAL_API_CIRCUIT_OPEN` 에러 코드를 포함한 커스텀 예외를 발생시키거나, `Mono.empty()`를 반환하여 후속 처리를 유도합니다.
---

## 개선 효과: 장애 격리를 통한 안정성 확보

이번 변경의 핵심 목표는 성능 향상이 아닌 **시스템 안정성(Stability) 및 회복탄력성(Resilience)** 확보입니다.

| 상황 | 개선 전 (서킷 브레이커 없음) | **개선 후 (서킷 브레이커 적용)** | 개선 효과 |
| :--- | :--- | :--- | :--- |
| **외부 API 응답 지연 시** | 요청 스레드가 모두 대기 상태에 빠져 **시스템 전체가 응답 불능(먹통) 상태**가 됨 | 초기 몇 번의 실패 후 서킷이 열려, 후속 요청은 **기다림 없이 즉시 실패(Fail-fast)** | **장애 전파 방지** 및 시스템 리소스 보호 |
| **외부 API 일시적 오류 시** | 오류가 발생하는 동안 모든 관련 기능 사용 불가 | 서킷이 열려있는 동안 대체 로직 수행, 서비스 자동 복구 시도(Half-Open) | **서비스 가용성 향상** |

---

# 🤔 고민한 내용

#### 1. 장애 전파 방지를 위한 서킷 브레이커 패턴 도입
-   **고민**: `foodiePass`는 환율, 번역, OCR 등 다수의 외부 API에 의존하고 있습니다. 이 중 하나만 장애가 발생해도 해당 기능을 사용하는 요청 스레드들이 모두 대기 상태에 빠져, 결국 전체 시스템의 스레드 풀을 고갈시키는 `연쇄 장애(Cascading Failure)`로 이어질 위험이 컸습니다.
-   **결정**: **Resilience4j를 이용한 서킷 브레이커 패턴**을 도입하여 각 외부 의존성을 격리하기로 결정했습니다.
-   **근거**: 서킷 브레이커는 특정 서비스의 실패를 감지하면 일시적으로 해당 서비스로의 요청을 자동으로 차단하고, 미리 정의된 Fallback 로직을 실행합니다. 이를 통해 문제가 발생한 컴포넌트를 격리하여 장애가 시스템 전체로 확산되는 것을 막고, 서버 리소스를 보호하여 안정성을 극대화할 수 있다고 생각하였습니다.

#### 2. Fallback 전략: 빠른 실패(Fail-fast) vs. 기본값 반환
-   **고민**: 서킷이 열렸을 때, Fallback 로직이 '기본값/빈 값'을 반환해야 할지, 아니면 '서킷이 열렸음'을 명시하는 예외를 던져야 할지 결정해야 했습니다.
-   **결정**: API의 특성과 후속 처리의 비즈니스 요구사항에 맞춰 두 가지 전략을 구분하여 적용했습니다.
    -   **`GeminiClient`, `GoogleFinanceRateProvider`**: `EXTERNAL_API_CIRCUIT_OPEN` 에러 코드를 포함한 예외를 던집니다. 이는 호출한 서비스에게 장애 상황을 명확히 알려 적절한 후속 처리를 하도록 유도합니다.
    -   **`TasteAtlasApiClient`**: `Mono.empty()`를 반환합니다. 이는 해당 정보를 가져오지 못하더라도, 후속 스트림에서 기본값으로 치환하는 등 비즈니스 로직상 유연한 처리가 가능하도록 설계되었습니다.
-   **근거**: Fallback 전략은 일관성도 중요하지만, 각 비즈니스 로직의 요구사항에 맞춰 다르게 설계하는 것이 시스템의 유연성을 높이는 데 더 효과적이라고 판단했습니다.

---