### PR TITLE
feat: ShedLock을 이용한 스케줄러 분산 락 적용 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,10 @@ dependencies {
 	implementation 'org.jsoup:jsoup:1.17.2'
 	implementation 'org.seleniumhq.selenium:selenium-java:4.22.0'
 
+	// ShedLock 의존성 추가
+	implementation 'net.javacrumbs.shedlock:shedlock-spring:5.14.0'
+	implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.14.0'
+
 	// Utils
 	implementation 'org.apache.commons:commons-text:1.12.0'
 

--- a/src/main/java/foodiepass/server/ServerApplication.java
+++ b/src/main/java/foodiepass/server/ServerApplication.java
@@ -4,10 +4,8 @@ import foodiepass.server.menu.infra.config.TasteAtlasProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableScheduling
 @EnableConfigurationProperties(TasteAtlasProperties.class)
 public class ServerApplication {
 

--- a/src/main/java/foodiepass/server/currency/application/ExchangeRateScheduler.java
+++ b/src/main/java/foodiepass/server/currency/application/ExchangeRateScheduler.java
@@ -5,6 +5,7 @@ import foodiepass.server.menu.application.port.out.ExchangeRateProvider;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
@@ -26,11 +27,12 @@ public class ExchangeRateScheduler {
     }
 
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @SchedulerLock(name = "updateAllExchangeRates", lockAtLeastFor = "PT5M", lockAtMostFor = "PT1H")
     public void scheduledCacheUpdate() {
         updateAllExchangeRatesInternal();
     }
 
-    private void updateAllExchangeRatesInternal() {
+    void updateAllExchangeRatesInternal() {
         log.info("환율 정보 캐시 갱신 작업을 시작합니다...");
 
         final Currency baseCurrency = Currency.UNITED_STATES_DOLLAR;

--- a/src/main/java/foodiepass/server/global/config/ShedLockConfig.java
+++ b/src/main/java/foodiepass/server/global/config/ShedLockConfig.java
@@ -1,0 +1,26 @@
+package foodiepass.server.global.config;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+import javax.sql.DataSource;
+
+@Configuration
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "PT30S")
+public class ShedLockConfig {
+
+    @Bean
+    public LockProvider lockProvider(DataSource dataSource) {
+        return new JdbcTemplateLockProvider(JdbcTemplateLockProvider.Configuration.builder()
+                .withJdbcTemplate(new JdbcTemplate(dataSource))
+                .usingDbTime()
+                .build()
+        );
+    }
+}

--- a/src/test/java/foodiepass/server/currency/application/ExchangeRateSchedulerLockTest.java
+++ b/src/test/java/foodiepass/server/currency/application/ExchangeRateSchedulerLockTest.java
@@ -1,0 +1,53 @@
+package foodiepass.server.currency.application;
+
+import foodiepass.server.menu.application.port.out.OcrReader;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.IntStream;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class ExchangeRateSchedulerLockTest {
+
+    @MockitoSpyBean
+    private ExchangeRateScheduler scheduler;
+
+    @MockitoBean
+    private OcrReader ocrReader;
+
+    @Test
+    @DisplayName("여러 스레드가 동시에 스케줄러를 실행하면, 락(Lock)에 의해 단 한 번만 실행된다")
+    void whenTasksRunConcurrently_thenOnlyOneShouldExecute() throws InterruptedException {
+        // given
+        int numberOfThreads = 5;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        // when
+        IntStream.range(0, numberOfThreads).forEach(i ->
+                executorService.submit(() -> {
+                    try {
+                        scheduler.scheduledCacheUpdate();
+                    } finally {
+                        latch.countDown();
+                    }
+                })
+        );
+
+        latch.await();
+
+        // then
+        verify(scheduler, times(1)).updateAllExchangeRatesInternal();
+    }
+}

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS shedlock (
+                                        name VARCHAR(64) NOT NULL,
+    lock_until TIMESTAMP(3) NOT NULL,
+    locked_at TIMESTAMP(3) NOT NULL,
+    locked_by VARCHAR(255) NOT NULL,
+    PRIMARY KEY (name)
+    );


### PR DESCRIPTION
# 📄 Work Description

향후 서버 인스턴스가 2대 이상으로 수평 확장될 경우를 대비하여, `@Scheduled` 작업이 모든 인스턴스에서 중복 실행되는 것을 방지하기 위해 데이터베이스 기반의 분산 락 라이브러리인 **ShedLock**을 도입했습니다.

-   **ShedLock 의존성 추가**:
    -   `shedlock-spring` 및 `shedlock-provider-jdbc-template` 라이브러리를 `build.gradle`에 추가했습니다.
-   **분산 락 설정 (`ShedLockConfig`)**:
    -   `@EnableSchedulerLock`을 통해 ShedLock 기능을 활성화하고, `JdbcTemplateLockProvider`를 빈으로 등록하여 데이터베이스를 락 저장소로 사용하도록 설정했습니다.
-   **스케줄러에 락 적용**:
    -   `ExchangeRateScheduler`의 `scheduledCacheUpdate()` 메소드에 `@SchedulerLock` 어노테이션을 추가하여, 여러 인스턴스 중 단 하나만 해당 작업을 수행하도록 보장합니다.

---

# 🤔 고민한 내용

#### 1. 스케줄러 중복 실행 문제의 선제적 해결
-   **고민**: 현재는 단일 인스턴스 환경이지만, 향후 서비스 트래픽 증가로 서버를 수평 확장(Scale-out)할 경우, `@Scheduled` 작업이 모든 인스턴스에서 중복 실행될 위험이 있다고 생각했습니다. 이는 외부 API 호출 비용을 N배로 증가시키고, 데이터 경합 상태를 유발할 수 있는 심각한 문제라고 판단하였습니다.
-   **결정**: 간단하면서도 안정적인 분산 락 구현체인 **ShedLock**을 도입하여 문제를 선제적으로 방지하기로 결정했습니다.
-   **근거**: ShedLock은 Zookeeper나 Redis 같은 별도의 인프라 없이, 기존에 사용하던 **데이터베이스(JDBC)를 락 저장소로 활용**할 수 있어 도입 비용이 매우 낮습니다. 어노테이션 기반으로 선언적으로 락을 관리할 수 있어 코드의 복잡성을 최소화하면서도, 분산 환경에서의 스케줄러 동작 정합성을 효과적으로 보장할 수 있다고 판단했습니다.

#### 2. 테스트 전략: 단위 테스트 vs. 통합 테스트
-   **고민**: 분산 락의 동작을 어떻게 신뢰성 있게 검증할 것인지 고민했습니다. Mock 객체를 사용하는 순수 단위 테스트로는 데이터베이스와의 실제 상호작용을 통한 락 획득/해제 과정을 검증할 수 없었습니다.
-   **결정**: 실제 스프링 컨텍스트와 H2 인메모리 데이터베이스를 모두 로드하는 **통합 테스트(`@SpringBootTest`)** 방식을 채택했습니다.
-   **근거**: 통합 테스트를 통해 ShedLock의 설정(`ShedLockConfig`)과 AOP 프록시가 모두 정상적으로 동작하는 환경을 구축했습니다. `ExecutorService`로 여러 스레드를 생성하여 **다수의 노드가 동시에 스케줄러를 실행하려는 상황을 시뮬레이션**하고, `@SpyBean`을 이용해 실제 내부 로직의 호출 횟수를 검증함으로써, 락이 의도대로 동작함을 명확하게 증명할 수 있었습니다.